### PR TITLE
Port c#-port-only fixes onto main: fullscreen, rounded UI, bold text,…

### DIFF
--- a/RotBoiRemastered.Tests/UI/MenusTests.cs
+++ b/RotBoiRemastered.Tests/UI/MenusTests.cs
@@ -13,8 +13,44 @@ namespace RotBoiRemastered.Tests.UI;
 /// left to visual smoke testing, same as the rest of this port's UI layer.
 /// </summary>
 [Collection("GameProfileState")]
-public class MenusTests
+public class MenusTests : IDisposable
 {
+    private readonly Dictionary<string, Keys?> _originalBindings;
+    private readonly string _originalSavePath;
+    private readonly GameProfileData _originalProfile;
+    private readonly string _tempDir;
+
+    // GameProfile.SavePath now defaults to a real per-user AppData path
+    // (see GameProfile.cs) rather than a working-directory-relative one, so
+    // this class -- like KeybindsTests -- must redirect to a scratch file
+    // and reset Profile/Bindings to defaults before every test. Without
+    // this, a machine with a real saved profile.json (e.g. one where
+    // "restart" was ever explicitly unbound) would make
+    // HandlePause_RestartKeybind_ReturnsRestart fail by loading that real,
+    // non-default state instead of Keybinds.ActionDefaults.
+    public MenusTests()
+    {
+        _originalBindings = new Dictionary<string, Keys?>(Keybinds.Bindings);
+        _originalSavePath = GameProfile.SavePath;
+        _originalProfile = GameProfile.Profile;
+        _tempDir = Directory.CreateTempSubdirectory("rotboi-menus-tests-").FullName;
+        GameProfile.SavePath = Path.Combine(_tempDir, "profile.json");
+        GameProfile.Profile = new GameProfileData();
+        Keybinds.Bindings.Clear();
+        foreach (var (actionId, defaultKey) in Keybinds.ActionDefaults)
+            Keybinds.Bindings[actionId] = defaultKey;
+    }
+
+    public void Dispose()
+    {
+        Keybinds.Bindings.Clear();
+        foreach (var (key, value) in _originalBindings)
+            Keybinds.Bindings[key] = value;
+        GameProfile.SavePath = _originalSavePath;
+        GameProfile.Profile = _originalProfile;
+        Directory.Delete(_tempDir, recursive: true);
+    }
+
     [Fact]
     public void HandlePause_Escape_ReturnsResume()
     {

--- a/RotBoiRemastered/Core/Primitives2D.cs
+++ b/RotBoiRemastered/Core/Primitives2D.cs
@@ -39,6 +39,52 @@ public static class Primitives2D
         FillRect(spriteBatch, new Rectangle(rect.Right - width, rect.Y, width, rect.Height), color); // right
     }
 
+    /// <summary>
+    /// Filled rectangle with rounded corners, matching pygame.draw.rect's
+    /// `border_radius` (ItemCards.cs/StatCards.cs/InformationSheet.cs icon
+    /// chrome previously rendered sharp-cornered for lack of this primitive).
+    /// Composed from a cross of two rects plus four filled corner circles --
+    /// correct for any convex axis-aligned rounded rect, which is everything
+    /// this codebase draws; not a true rounded-rect mesh (SpriteBatch has no
+    /// vertex renderer available here).
+    /// </summary>
+    public static void FillRoundedRect(SpriteBatch spriteBatch, Rectangle rect, Color color, int radius)
+    {
+        radius = Math.Max(0, Math.Min(radius, Math.Min(rect.Width, rect.Height) / 2));
+        if (radius <= 0)
+        {
+            FillRect(spriteBatch, rect, color);
+            return;
+        }
+        FillRect(spriteBatch, new Rectangle(rect.X + radius, rect.Y, rect.Width - radius * 2, rect.Height), color);
+        FillRect(spriteBatch, new Rectangle(rect.X, rect.Y + radius, radius, rect.Height - radius * 2), color);
+        FillRect(spriteBatch, new Rectangle(rect.Right - radius, rect.Y + radius, radius, rect.Height - radius * 2), color);
+        FillCircle(spriteBatch, new Vector2(rect.X + radius, rect.Y + radius), radius, color);
+        FillCircle(spriteBatch, new Vector2(rect.Right - radius, rect.Y + radius), radius, color);
+        FillCircle(spriteBatch, new Vector2(rect.X + radius, rect.Bottom - radius), radius, color);
+        FillCircle(spriteBatch, new Vector2(rect.Right - radius, rect.Bottom - radius), radius, color);
+    }
+
+    /// <summary>Border-only rounded rect, matching pygame.draw.rect(..., width>0, border_radius=...) -- four corner arcs plus four straight edges.</summary>
+    public static void RoundedRectOutline(SpriteBatch spriteBatch, Rectangle rect, Color color, int width, int radius)
+    {
+        radius = Math.Max(0, Math.Min(radius, Math.Min(rect.Width, rect.Height) / 2));
+        if (radius <= 0)
+        {
+            RectOutline(spriteBatch, rect, color, width);
+            return;
+        }
+        int diameter = radius * 2;
+        Arc(spriteBatch, new Rectangle(rect.X, rect.Y, diameter, diameter), MathF.PI, MathF.PI * 1.5f, color, width);
+        Arc(spriteBatch, new Rectangle(rect.Right - diameter, rect.Y, diameter, diameter), MathF.PI * 1.5f, MathF.Tau, color, width);
+        Arc(spriteBatch, new Rectangle(rect.Right - diameter, rect.Bottom - diameter, diameter, diameter), 0, MathF.PI * .5f, color, width);
+        Arc(spriteBatch, new Rectangle(rect.X, rect.Bottom - diameter, diameter, diameter), MathF.PI * .5f, MathF.PI, color, width);
+        Line(spriteBatch, new Vector2(rect.X + radius, rect.Y), new Vector2(rect.Right - radius, rect.Y), color, width);
+        Line(spriteBatch, new Vector2(rect.X + radius, rect.Bottom), new Vector2(rect.Right - radius, rect.Bottom), color, width);
+        Line(spriteBatch, new Vector2(rect.X, rect.Y + radius), new Vector2(rect.X, rect.Bottom - radius), color, width);
+        Line(spriteBatch, new Vector2(rect.Right, rect.Y + radius), new Vector2(rect.Right, rect.Bottom - radius), color, width);
+    }
+
     public static void Line(SpriteBatch spriteBatch, Vector2 start, Vector2 end, Color color, int width)
     {
         Vector2 delta = end - start;

--- a/RotBoiRemastered/Core/RotBoiGame.cs
+++ b/RotBoiRemastered/Core/RotBoiGame.cs
@@ -66,6 +66,8 @@ public class RotBoiGame : Game
         Window.ClientSizeChanged += (_, _) =>
             _session?.Resize(GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height);
         base.Initialize();
+        if (GameProfile.Profile.Fullscreen)
+            ApplyFullscreen(true, persist: false);
     }
 
     protected override void LoadContent()
@@ -155,15 +157,21 @@ public class RotBoiGame : Game
         base.Update(gameTime);
     }
 
-    private void ToggleFullscreen()
+    private void ToggleFullscreen() => ApplyFullscreen(!_graphics.IsFullScreen, persist: true);
+
+    /// <summary>
+    /// Applies (and, once GraphicsDevice exists, persists) fullscreen state
+    /// directly rather than toggling blindly -- lets both the F11 hotkey and
+    /// the pause menu's OPTIONS-tab checkbox drive the same idempotent path,
+    /// and lets startup restore a saved preference without needing a spurious
+    /// toggle. `persist` is false on the very first call from Initialize
+    /// (before GraphicsDevice/GraphicsAdapter are guaranteed ready and before
+    /// there's anything new to save back to a profile that already has this
+    /// exact value).
+    /// </summary>
+    private void ApplyFullscreen(bool fullscreen, bool persist)
     {
-        if (_graphics.IsFullScreen)
-        {
-            _graphics.IsFullScreen = false;
-            _graphics.PreferredBackBufferWidth = _windowedWidth;
-            _graphics.PreferredBackBufferHeight = _windowedHeight;
-        }
-        else
+        if (fullscreen)
         {
             _windowedWidth = Math.Max(640, GraphicsDevice.Viewport.Width);
             _windowedHeight = Math.Max(360, GraphicsDevice.Viewport.Height);
@@ -173,8 +181,19 @@ public class RotBoiGame : Game
             _graphics.PreferredBackBufferHeight = mode.Height;
             _graphics.IsFullScreen = true;
         }
+        else
+        {
+            _graphics.IsFullScreen = false;
+            _graphics.PreferredBackBufferWidth = _windowedWidth;
+            _graphics.PreferredBackBufferHeight = _windowedHeight;
+        }
         _graphics.ApplyChanges();
         _session?.Resize(GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height);
+        if (persist)
+        {
+            GameProfile.Profile.Fullscreen = fullscreen;
+            GameProfile.SaveProfile();
+        }
     }
 
     /// <summary>Ported from main.py's baseInputCollection()'s event-drain shape, using polled state diffs instead of a pygame event queue.</summary>
@@ -359,6 +378,11 @@ public class RotBoiGame : Game
             _session.State.AutoFire = GameProfile.Profile.AutoFire;
             _session.Resize(GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height);
         }
+        // The OPTIONS-tab checkbox flips GameProfile.Profile.Fullscreen directly
+        // (same as any other GameplayOptions toggle); reconcile the actual
+        // window state against it here, same path F11's ToggleFullscreen uses.
+        if (GameProfile.Profile.Fullscreen != _graphics.IsFullScreen)
+            ApplyFullscreen(GameProfile.Profile.Fullscreen, persist: false);
         switch (action)
         {
             case MenuAction.Resume:
@@ -469,8 +493,8 @@ public class RotBoiGame : Game
         session.DrawEnemyProjectiles(_spriteBatch);
         session.DrawDamageTexts(_spriteBatch);
         session.DrawExperience(_spriteBatch);
-        session.DrawLootCrates(_spriteBatch);
         _spriteBatch.End();
+        session.DrawLootCrates(_spriteBatch, GraphicsDevice);
 
         _spriteBatch.Begin();
         session.DrawCombatOverlays(_spriteBatch, InputState.MousePosition);

--- a/RotBoiRemastered/Entities/Beaudis.cs
+++ b/RotBoiRemastered/Entities/Beaudis.cs
@@ -429,7 +429,7 @@ public sealed class Beaudis : Enemy
         else if (PhaseAnnouncementTimer > 0)
         {
             UiTheme.DrawText(spriteBatch, $"PHASE {Phase} // {PhaseLabel}", Math.Max(11, Size * .13), PhaseAccent,
-                new Vector2(rect.Center.X, screenPosition.Y - 10), "midbottom");
+                new Vector2(rect.Center.X, screenPosition.Y - 10), "midbottom", bold: true);
         }
     }
 }

--- a/RotBoiRemastered/Entities/Dissonance.cs
+++ b/RotBoiRemastered/Entities/Dissonance.cs
@@ -2137,7 +2137,7 @@ public sealed class Dissonance : Enemy
         bubble.Y = Math.Clamp(bubble.Y, bounds.Y, Math.Max(bounds.Y, bounds.Bottom - bubble.Height));
 
         UiTheme.DrawPanel(spriteBatch, bubble, UiTheme.PanelRaised, PhaseAccent, shadow: 4);
-        UiTheme.DrawText(spriteBatch, runeName, 13, UiTheme.Cream, new Vector2(bubble.Center.X - phaseFont.MeasureString($"  {PhaseLabel}").X / 2f, bubble.Y + 7), "midtop");
+        UiTheme.DrawText(spriteBatch, runeName, 13, UiTheme.Cream, new Vector2(bubble.Center.X - phaseFont.MeasureString($"  {PhaseLabel}").X / 2f, bubble.Y + 7), "midtop", bold: true);
         UiTheme.DrawText(spriteBatch, $"  {PhaseLabel}", 13, UiTheme.Cream, new Vector2(bubble.Center.X + runeFont.MeasureString(runeName).X / 2f, bubble.Y + 7), "midtop");
         float flavorY = bubble.Bottom - 7 - flavorHeight;
         foreach (var line in lines)

--- a/RotBoiRemastered/Systems/GameProfile.cs
+++ b/RotBoiRemastered/Systems/GameProfile.cs
@@ -36,6 +36,8 @@ public sealed class GameProfileData
     public string PlayerEdgeColor { get; set; } = "ink";
     public string ProjectileColor { get; set; } = "reference";
     public string ProjectileDesign { get; set; } = "bulb";
+    /// <summary>Native-resolution fullscreen, toggled via F11 or the pause menu's OPTIONS tab (RotBoiGame.ApplyFullscreen). Defaults off -- windowed is friendlier for a desktop app that hasn't asked first.</summary>
+    public bool Fullscreen { get; set; }
 
     /// <summary>Action id -> key code (as int) or null for unbound. See Keybinds.cs.</summary>
     public Dictionary<string, int?> Keybinds { get; set; } = new();
@@ -77,7 +79,22 @@ public static class GameProfile
     /// mock.patch.object(gameProfile, "save_profile", ...), but here it
     /// actually exercises a real save/load round trip against a scratch file.
     /// </summary>
-    public static string SavePath { get; set; } = "data/profile.json";
+    public static string SavePath { get; set; } = DefaultSavePath();
+
+    /// <summary>
+    /// A per-user AppData folder (`%APPDATA%\RotBoiRemastered\profile.json`
+    /// on Windows; `Environment.SpecialFolder.ApplicationData` resolves to
+    /// the platform-appropriate equivalent elsewhere) rather than a path
+    /// relative to the working directory -- a real installed build's working
+    /// directory isn't guaranteed writable or even stable (e.g. Program
+    /// Files), unlike a `dotnet run` dev invocation where the project folder
+    /// always is.
+    /// </summary>
+    private static string DefaultSavePath()
+    {
+        string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        return Path.Combine(appData, "RotBoiRemastered", "profile.json");
+    }
 
     public static GameProfileData Profile { get; set; } = LoadProfile();
 

--- a/RotBoiRemastered/Systems/GameSession.cs
+++ b/RotBoiRemastered/Systems/GameSession.cs
@@ -924,9 +924,23 @@ public sealed class GameSession
         }
     }
 
-    /// <summary>Ported from character.py's updateLootCrates(). Viewport clipping against the (not yet built) HUD sidebar is deferred.</summary>
-    public void DrawLootCrates(SpriteBatch spriteBatch)
+    private static readonly RasterizerState LootCrateScissorRasterizerState = new() { ScissorTestEnable = true, CullMode = CullMode.None };
+
+    /// <summary>
+    /// Ported from character.py's updateLootCrates(): clips crate drawing to
+    /// the arena viewport so a crate can't paint over the HUD sidebar. The
+    /// rect-intersects culling this used to rely on only skipped crates
+    /// whose bounding box missed the viewport entirely -- one straddling the
+    /// boundary still bled its far side into the sidebar, since culling
+    /// isn't clipping. Opens/closes its own scissor-scoped SpriteBatch pass,
+    /// same contract as DrawBackground/ArenaRenderer.Draw -- the caller must
+    /// not have a batch already open when calling this.
+    /// </summary>
+    public void DrawLootCrates(SpriteBatch spriteBatch, GraphicsDevice graphicsDevice)
     {
+        var previousScissor = graphicsDevice.ScissorRectangle;
+        graphicsDevice.ScissorRectangle = new Rectangle(0, 0, InformationSheet.ArenaWidth, ScreenHeight);
+        spriteBatch.Begin(rasterizerState: LootCrateScissorRasterizerState);
         foreach (var crate in State.LootCrateList)
         {
             var screen = Camera.ApplyZoom(Camera.WorldToScreen(new Vector2(crate.WorldX, crate.WorldY), PlayerWorldCenter, ScreenShake));
@@ -934,6 +948,8 @@ public sealed class GameSession
             if (rect.Intersects(new Rectangle(0, 0, InformationSheet.ArenaWidth, ScreenHeight)))
                 crate.Draw(spriteBatch, Camera, PlayerWorldCenter, ScreenShake);
         }
+        spriteBatch.End();
+        graphicsDevice.ScissorRectangle = previousScissor;
     }
 
     /// <summary>Ported from character.py's crateInteractionForPlayer(). The drag-in-progress guard is dropped (InformationSheet's drag UI is deferred).</summary>

--- a/RotBoiRemastered/UI/InformationSheet.cs
+++ b/RotBoiRemastered/UI/InformationSheet.cs
@@ -54,9 +54,6 @@ namespace RotBoiRemastered.UI;
 ///   RunState's enemy/boss data, no HUD concern) and passed into
 ///   <see cref="DrawSheet"/> explicitly, rather than this class reaching
 ///   into GameSession itself.
-/// - Known rendering gap shared with ItemCards.cs/StatCards.cs: pygame's
-///   `border_radius` (rounded corners) has no `Primitives2D` equivalent yet,
-///   so equipment/loot slot boxes render sharp-cornered instead of rounded.
 /// </summary>
 public sealed class InformationSheet
 {
@@ -456,7 +453,7 @@ public sealed class InformationSheet
         string? rating, string? helpText, Point mousePosition)
     {
         var iconRect = new Rectangle(rect.X + Px(10), y - Px(3), Px(24), Px(24));
-        Primitives2D.FillRect(spriteBatch, iconRect, UiTheme.Ink);
+        Primitives2D.FillRoundedRect(spriteBatch, iconRect, UiTheme.Ink, Px(3));
         StatCards.DrawStatSymbol(spriteBatch, symbol, Inflated(iconRect, -Px(4), -Px(4)), UiTheme.Cream);
         var labelRect = UiTheme.DrawText(spriteBatch, label, Px(8), UiTheme.Muted, new Vector2(iconRect.Right + Px(7), y));
         UiTheme.DrawText(spriteBatch, value, Px(9), UiTheme.Text, new Vector2(iconRect.Right + Px(7), y + Px(12)));

--- a/RotBoiRemastered/UI/ItemCards.cs
+++ b/RotBoiRemastered/UI/ItemCards.cs
@@ -5,16 +5,7 @@ using RotBoiRemastered.Systems;
 
 namespace RotBoiRemastered.UI;
 
-/// <summary>
-/// Resolution-independent icons and mini cards for equippable loot items.
-/// Ported from itemCards.py.
-///
-/// Known difference from the Python original: pygame.draw.rect's
-/// `border_radius` (rounded corners on the armor icon body and the card
-/// chrome) has no Primitives2D equivalent (no rounded-rect primitive exists
-/// yet) -- both render as sharp-cornered rects instead. Purely cosmetic;
-/// revisit if a rounded-rect primitive gets added for some other module.
-/// </summary>
+/// <summary>Resolution-independent icons and mini cards for equippable loot items. Ported from itemCards.py.</summary>
 public static class ItemCards
 {
     private static void DrawLine(SpriteBatch spriteBatch, Color color, Vector2 start, Vector2 end, float width)
@@ -84,7 +75,7 @@ public static class ItemCards
                 var body = new Rectangle(0, 0, (int)(13 * unit), (int)(15 * unit));
                 body.X = (int)(cx - body.Width / 2f);
                 body.Y = (int)(cy + 1 * unit - body.Height / 2f);
-                Primitives2D.RectOutline(spriteBatch, body, drawColor, (int)stroke);
+                Primitives2D.RoundedRectOutline(spriteBatch, body, drawColor, (int)stroke, (int)MathF.Round(3 * unit));
                 DrawLine(spriteBatch, drawColor, new Vector2(cx, cy - 6 * unit), new Vector2(cx - 3 * unit, cy - 1 * unit), Math.Max(1f, stroke * .7f));
                 DrawLine(spriteBatch, drawColor, new Vector2(cx, cy - 6 * unit), new Vector2(cx + 3 * unit, cy - 1 * unit), Math.Max(1f, stroke * .7f));
                 if (visualKind == "chain")
@@ -164,11 +155,12 @@ public static class ItemCards
     public static Rectangle DrawItemCard(SpriteBatch spriteBatch, Rectangle rect, string slotType, string rarity, bool hovered = false)
     {
         Color rarityColor = UiTheme.RarityColors.TryGetValue(rarity, out var color) ? color : UiTheme.Border;
+        int cornerRadius = Math.Max(2, rect.Width / 8);
         var shadow = new Rectangle(rect.X + Math.Max(2, rect.Width / 12), rect.Y + Math.Max(2, rect.Width / 12), rect.Width, rect.Height);
-        Primitives2D.FillRect(spriteBatch, shadow, UiTheme.Shadow);
+        Primitives2D.FillRoundedRect(spriteBatch, shadow, UiTheme.Shadow, cornerRadius);
         Color fill = hovered ? UiTheme.Lighten(rarityColor, 24) : rarityColor;
-        Primitives2D.FillRect(spriteBatch, rect, fill);
-        Primitives2D.RectOutline(spriteBatch, rect, UiTheme.Ink, Math.Max(2, rect.Width / 14));
+        Primitives2D.FillRoundedRect(spriteBatch, rect, fill, cornerRadius);
+        Primitives2D.RoundedRectOutline(spriteBatch, rect, UiTheme.Ink, Math.Max(2, rect.Width / 14), cornerRadius);
         var inner = rect;
         inner.Inflate((int)(-rect.Width * .18f), (int)(-rect.Height * .22f));
         DrawItemSymbol(spriteBatch, slotType, inner, UiTheme.Ink);
@@ -178,10 +170,11 @@ public static class ItemCards
     public static Rectangle DrawItemCard(SpriteBatch spriteBatch, Rectangle rect, ItemDrop item, bool hovered = false)
     {
         Color rarityColor = UiTheme.RarityColors.TryGetValue(item.Rarity, out var color) ? color : UiTheme.Border;
+        int cornerRadius = Math.Max(2, rect.Width / 8);
         var shadow = new Rectangle(rect.X + Math.Max(2, rect.Width / 12), rect.Y + Math.Max(2, rect.Width / 12), rect.Width, rect.Height);
-        Primitives2D.FillRect(spriteBatch, shadow, UiTheme.Shadow);
-        Primitives2D.FillRect(spriteBatch, rect, hovered ? UiTheme.Lighten(rarityColor, 24) : rarityColor);
-        Primitives2D.RectOutline(spriteBatch, rect, UiTheme.Ink, Math.Max(2, rect.Width / 14));
+        Primitives2D.FillRoundedRect(spriteBatch, shadow, UiTheme.Shadow, cornerRadius);
+        Primitives2D.FillRoundedRect(spriteBatch, rect, hovered ? UiTheme.Lighten(rarityColor, 24) : rarityColor, cornerRadius);
+        Primitives2D.RoundedRectOutline(spriteBatch, rect, UiTheme.Ink, Math.Max(2, rect.Width / 14), cornerRadius);
         var inner = rect;
         inner.Inflate((int)(-rect.Width * .15f), (int)(-rect.Height * .18f));
         DrawItemSymbol(spriteBatch, item.SlotType, inner, UiTheme.Ink, item.Definition.VisualKind);

--- a/RotBoiRemastered/UI/Menus.cs
+++ b/RotBoiRemastered/UI/Menus.cs
@@ -222,6 +222,13 @@ public sealed class Menus
             var damageRect = new Rectangle(sliderX, guiRect.Bottom + rowGap, sliderWidth, rowHeight);
             Slider(spriteBatch, "damage_text_size", damageRect, "DAMAGE TEXT SIZE", $"{GameProfile.Profile.DamageTextSize * 100:0}%",
                 GameProfile.Profile.DamageTextSize, UiTheme.MinDamageTextScale, UiTheme.MaxDamageTextScale, mousePosition, UiTheme.Red);
+
+            var fullscreenRect = new Rectangle(sliderX, damageRect.Bottom + rowGap, sliderWidth, (int)(42 * scale));
+            bool fullscreen = GameProfile.Profile.Fullscreen;
+            Button(spriteBatch, "fullscreen", fullscreenRect, $"FULLSCREEN  //  {(fullscreen ? "ON" : "OFF")}",
+                mousePosition, mouseDown, fullscreen ? UiTheme.Green : UiTheme.Border);
+            UiTheme.DrawText(spriteBatch, "Native-resolution fullscreen (F11 also toggles this)", 8 * scale, UiTheme.Muted,
+                new Vector2(fullscreenRect.X + 10 * scale, fullscreenRect.Bottom - 4 * scale), "bottomleft");
         }
         else
         {
@@ -315,6 +322,8 @@ public sealed class Menus
                 GameProfile.Profile.ScreenShake = levels[(idx + 1) % levels.Length];
                 GameProfile.SaveProfile();
             }
+            if (Activated("fullscreen", mousePosition, mousePressed))
+                GameProfile.Toggle("Fullscreen");
             if (mouseDown)
             {
                 if (_activeSlider is null)

--- a/RotBoiRemastered/UI/StatCards.cs
+++ b/RotBoiRemastered/UI/StatCards.cs
@@ -4,15 +4,7 @@ using RotBoiRemastered.Core;
 
 namespace RotBoiRemastered.UI;
 
-/// <summary>
-/// Resolution-independent stat symbols and collectible mini upgrade cards.
-/// Ported from statCards.py.
-///
-/// Known difference: pygame's `border_radius` (rounded corners on the
-/// bullet-icon body and the card chrome) has no `Primitives2D` equivalent
-/// yet, so both render with sharp corners instead -- same documented gap as
-/// `ItemCards.cs`.
-/// </summary>
+/// <summary>Resolution-independent stat symbols and collectible mini upgrade cards. Ported from statCards.py.</summary>
 public static class StatCards
 {
     private static void DrawLine(SpriteBatch spriteBatch, Color color, Vector2 start, Vector2 end, float width)
@@ -38,7 +30,7 @@ public static class StatCards
         {
             float length = 10 * unit * scale, radius = 3.5f * unit * scale;
             var body = new Rectangle((int)(x - length * .45f), (int)(y - radius), (int)(length * .65f), (int)(radius * 2));
-            Primitives2D.FillRect(spriteBatch, body, drawColor);
+            Primitives2D.FillRoundedRect(spriteBatch, body, drawColor, Math.Max(1, (int)MathF.Round(radius)));
             var tip = new[]
             {
                 new Vector2(body.Right - unit, body.Top),
@@ -191,11 +183,12 @@ public static class StatCards
         string mathType, bool hovered = false)
     {
         Color rarityColor = UiTheme.RarityColors.TryGetValue(rarity, out var color) ? color : UiTheme.Border;
+        int cornerRadius = Math.Max(2, rect.Width / 8);
         var shadow = new Rectangle(rect.X + Math.Max(2, rect.Width / 12), rect.Y + Math.Max(2, rect.Width / 12), rect.Width, rect.Height);
-        Primitives2D.FillRect(spriteBatch, shadow, UiTheme.Shadow);
+        Primitives2D.FillRoundedRect(spriteBatch, shadow, UiTheme.Shadow, cornerRadius);
         Color fill = hovered ? UiTheme.Lighten(rarityColor, 24) : rarityColor;
-        Primitives2D.FillRect(spriteBatch, rect, fill);
-        Primitives2D.RectOutline(spriteBatch, rect, UiTheme.Ink, Math.Max(2, rect.Width / 14));
+        Primitives2D.FillRoundedRect(spriteBatch, rect, fill, cornerRadius);
+        Primitives2D.RoundedRectOutline(spriteBatch, rect, UiTheme.Ink, Math.Max(2, rect.Width / 14), cornerRadius);
         var inner = rect;
         inner.Inflate((int)(-rect.Width * .18f), (int)(-rect.Height * .22f));
         DrawStatSymbol(spriteBatch, statName, inner, UiTheme.Ink);

--- a/RotBoiRemastered/UI/UiTheme.cs
+++ b/RotBoiRemastered/UI/UiTheme.cs
@@ -93,10 +93,13 @@ public static class UiTheme
     public static double TextScaleMultiplier() => GameProfile.Profile.TextSize;
 
     /// <summary>
-    /// Italic/bold are accepted for signature parity with uiTheme.py (used by
-    /// not-yet-ported bossTypes.py) but not yet implemented -- there's only
-    /// one font file and no synthetic style synthesis wired up yet. Both
-    /// currently render at regular weight/slant.
+    /// `italic` is accepted for signature parity with uiTheme.py's font()
+    /// but not implemented -- there's only one regular-weight font file and
+    /// no glyph-shear renderer available through FontStashSharp/SpriteBatch
+    /// to synthesize a slant safely. `bold` is real: DrawText below
+    /// synthesizes it with a 1px-offset double draw (a standard technique
+    /// for a single-weight font file), the same visual effect pygame's
+    /// `set_bold(True)` gives a boss's phase-announcement label.
     /// </summary>
     public static DynamicSpriteFont Font(double size, bool italic = false, bool bold = false)
     {
@@ -119,14 +122,17 @@ public static class UiTheme
     }
 
     public static Rectangle DrawText(SpriteBatch spriteBatch, object value, double size, Color? color = null,
-        Vector2? position = null, string anchor = "topleft")
+        Vector2? position = null, string anchor = "topleft", bool bold = false)
     {
         string text = value.ToString() ?? "";
         var font = Font(size);
         Vector2 pos = position ?? Vector2.Zero;
         Vector2 measured = font.MeasureString(text);
         var rect = AnchoredRect(pos, measured, anchor);
-        font.DrawText(spriteBatch, text, new Vector2(rect.X, rect.Y), color ?? Text);
+        Color drawColor = color ?? Text;
+        if (bold)
+            font.DrawText(spriteBatch, text, new Vector2(rect.X + 1, rect.Y), drawColor);
+        font.DrawText(spriteBatch, text, new Vector2(rect.X, rect.Y), drawColor);
         return rect;
     }
 


### PR DESCRIPTION
… crate clipping, AppData saves

main had already absorbed the bulk of c#-port's work (per-path content, HUD overlays, gamepad, the Escape/pause double-processing fix) through a separate independently-developed C# rewrite, but five smaller pieces never made it across:

- Fullscreen: main already had an F11 hotkey but no persistence or menu discoverability. Added GameProfileData.Fullscreen, a pause-menu OPTIONS checkbox, and startup restoration, all routed through one idempotent ApplyFullscreen(bool, persist) so F11 and the checkbox share one path.
- Rounded UI corners: added Primitives2D.FillRoundedRect/RoundedRectOutline, wired into ItemCards/StatCards card chrome and the loadout stat icon.
- Bold text: UiTheme.DrawText now synthesizes bold via a 1px-offset double draw, wired into Beaudis's and Dissonance's phase-announcement labels.
- Loot crate clipping: main's DrawLootCrates only culled by bounding-box intersection, so a crate straddling the sidebar boundary still bled through. Switched to real GPU scissor-clipping, same contract as DrawBackground/ArenaRenderer.
- Profile save path: moved GameProfile.SavePath's default from a working-directory-relative path to %APPDATA%\RotBoiRemastered\profile.json.

That last change immediately surfaced a real, pre-existing test-isolation gap: MenusTests never reset GameProfile.Profile/Keybinds.Bindings before running, so it silently depended on nothing real living at the default save path. Gave it the same temp-profile isolation KeybindsTests already uses.