### PR TITLE
Fix text-scale overflow and clean up the information panel

### DIFF
--- a/RotBoiRemastered.Tests/Systems/GameProfileTests.cs
+++ b/RotBoiRemastered.Tests/Systems/GameProfileTests.cs
@@ -24,7 +24,6 @@ public class GameProfileTests : IDisposable
         Assert.Equal(defaults.DamageNumbers, profile.DamageNumbers);
         Assert.Equal(defaults.AimGuide, profile.AimGuide);
         Assert.Equal(defaults.HighContrast, profile.HighContrast);
-        Assert.Equal(defaults.HudMode, profile.HudMode);
         Assert.Equal(defaults.TextSize, profile.TextSize);
         Assert.Equal(defaults.GuiScale, profile.GuiScale);
         Assert.Equal(defaults.DamageTextSize, profile.DamageTextSize);
@@ -91,9 +90,8 @@ public class GameProfileTests : IDisposable
                 BestLevel = 20,
                 BestKills = 193,
                 CompletedRuns = 2,
-                HudMode = "expanded",
-                TextSize = 1.3,
-                GuiScale = 1.4,
+                TextSize = 1.4,
+                GuiScale = 1.15,
                 DamageTextSize = .65,
                 Keybinds = new Dictionary<string, int?> { ["dash"] = 42, ["move_up"] = null },
             };
@@ -105,9 +103,8 @@ public class GameProfileTests : IDisposable
             Assert.Equal(20, reloaded.BestLevel);
             Assert.Equal(193, reloaded.BestKills);
             Assert.Equal(2, reloaded.CompletedRuns);
-            Assert.Equal("expanded", reloaded.HudMode);
-            Assert.Equal(1.3, reloaded.TextSize);
-            Assert.Equal(1.4, reloaded.GuiScale);
+            Assert.Equal(1.4, reloaded.TextSize);
+            Assert.Equal(1.15, reloaded.GuiScale);
             Assert.Equal(.65, reloaded.DamageTextSize);
             Assert.Equal(42, reloaded.Keybinds["dash"]);
             Assert.Null(reloaded.Keybinds["move_up"]);

--- a/RotBoiRemastered.Tests/UI/InformationSheetTests.cs
+++ b/RotBoiRemastered.Tests/UI/InformationSheetTests.cs
@@ -18,35 +18,23 @@ namespace RotBoiRemastered.Tests.UI;
 public class InformationSheetTests
 {
     [Fact]
-    public void Constructor_CompactMode_NarrowerThanExpanded()
-    {
-        GameProfile.Profile.HudMode = "compact";
-        var compact = new InformationSheet(1920, 1080);
-        GameProfile.Profile.HudMode = "expanded";
-        var expanded = new InformationSheet(1920, 1080);
-
-        Assert.True(compact.ArenaWidth > expanded.ArenaWidth);
-    }
-
-    [Fact]
     public void ArenaWidth_NeverExceeds42PercentOfScreen()
     {
-        GameProfile.Profile.HudMode = "expanded";
         var sheet = new InformationSheet(800, 600);
         Assert.True(800 - sheet.ArenaWidth <= 800 * .42);
     }
 
     [Fact]
-    public void ToggleMode_PersistsToProfileAndChangesArenaWidth()
+    public void ToggleWeaponStats_DoesNotChangeArenaWidthOrTouchProfile()
     {
-        GameProfile.Profile.HudMode = "compact";
         var sheet = new InformationSheet(1920, 1080);
         int before = sheet.ArenaWidth;
+        var profileBefore = GameProfile.Profile;
 
-        sheet.ToggleMode();
+        sheet.ToggleWeaponStats();
 
-        Assert.Equal("expanded", GameProfile.Profile.HudMode);
-        Assert.NotEqual(before, sheet.ArenaWidth);
+        Assert.Equal(before, sheet.ArenaWidth);
+        Assert.Same(profileBefore, GameProfile.Profile);
     }
 
     [Fact]

--- a/RotBoiRemastered.Tests/UI/UiThemeTests.cs
+++ b/RotBoiRemastered.Tests/UI/UiThemeTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework;
+using RotBoiRemastered.Systems;
 using RotBoiRemastered.UI;
 
 namespace RotBoiRemastered.Tests.UI;
@@ -8,9 +9,24 @@ namespace RotBoiRemastered.Tests.UI;
 /// Python test (test_sidebar_remains_bounded_across_common_aspect_ratios)
 /// depends on InformationSheet, which isn't ported yet -- port it alongside
 /// UI/InformationSheet.cs.
+///
+/// DisplayScale reads GameProfile.Profile.GuiScale, and GameProfile.Profile
+/// is process-wide static state seeded from whatever the developer's real
+/// %APPDATA% save file happens to contain -- so this needs the same
+/// GameProfileState collection (serializes against GameProfileTests/
+/// InformationSheetTests) plus its own reset-to-defaults, or these
+/// assertions (written assuming GuiScale's 1.0 default) go flaky the moment
+/// a live save has a non-default GuiScale on disk.
 /// </summary>
-public class UiThemeTests
+[Collection("GameProfileState")]
+public class UiThemeTests : IDisposable
 {
+    private readonly GameProfileData _originalProfile = GameProfile.Profile;
+
+    public UiThemeTests() => GameProfile.Profile = new GameProfileData();
+
+    public void Dispose() => GameProfile.Profile = _originalProfile;
+
     [Fact]
     public void ReferenceResolution_UsesOneToOneUiScale()
     {

--- a/RotBoiRemastered/Core/RotBoiGame.cs
+++ b/RotBoiRemastered/Core/RotBoiGame.cs
@@ -242,7 +242,7 @@ public class RotBoiGame : Game
             GameProfile.SaveProfile();
         }
         if (Keybinds.Pressed("hud_toggle") && State == GameState.GameRun)
-            _session!.ToggleHudMode();
+            _session!.ToggleWeaponStats();
         if (Keybinds.Pressed("dev_invincible") && _session is not null)
             _session.State.BossDebugInvincible = !_session.State.BossDebugInvincible;
         if (Keybinds.Pressed("dev_level_up") && State == GameState.GameRun)

--- a/RotBoiRemastered/Systems/GameProfile.cs
+++ b/RotBoiRemastered/Systems/GameProfile.cs
@@ -28,7 +28,6 @@ public sealed class GameProfileData
     public bool DamageNumbers { get; set; } = true;
     public bool AimGuide { get; set; }
     public bool HighContrast { get; set; }
-    public string HudMode { get; set; } = "compact";
     public double TextSize { get; set; } = 1.0;
     public double GuiScale { get; set; } = 1.0;
     public double DamageTextSize { get; set; } = 0.8;
@@ -118,10 +117,35 @@ public static class GameProfile
         return new GameProfileData();
     }
 
+    /// <summary>
+    /// GuiScale is preset-only (see UiTheme.GuiScaleLevels' doc comment) --
+    /// snap rather than clamp, so a profile.json saved by an older build
+    /// with a continuous in-between value (or the old, wider slider range)
+    /// lands on the closest still-valid preset instead of an unreachable-
+    /// through-the-UI value that happened to also be in-range. TextSize is
+    /// back to being a plain slider (see Menus.cs's "text_size" control),
+    /// so it's clamped rather than snapped -- see Normalize() below.
+    /// </summary>
+    private static double SnapToNearest(IReadOnlyList<double> levels, double value)
+    {
+        double closest = levels[0];
+        double bestDiff = Math.Abs(value - closest);
+        foreach (double level in levels)
+        {
+            double diff = Math.Abs(value - level);
+            if (diff < bestDiff)
+            {
+                bestDiff = diff;
+                closest = level;
+            }
+        }
+        return closest;
+    }
+
     private static void Normalize(GameProfileData profile)
     {
         profile.TextSize = Math.Clamp(profile.TextSize, UiTheme.MinTextScale, UiTheme.MaxTextScale);
-        profile.GuiScale = Math.Clamp(profile.GuiScale, UiTheme.MinGuiScale, UiTheme.MaxGuiScale);
+        profile.GuiScale = SnapToNearest(UiTheme.GuiScaleLevels, profile.GuiScale);
         profile.DamageTextSize = Math.Clamp(profile.DamageTextSize, UiTheme.MinDamageTextScale, UiTheme.MaxDamageTextScale);
         profile.Keybinds ??= new();
         profile.SkillLevels ??= new();

--- a/RotBoiRemastered/Systems/GameSession.cs
+++ b/RotBoiRemastered/Systems/GameSession.cs
@@ -105,12 +105,13 @@ public sealed class GameSession
         Camera.Lock = new Vector2(InformationSheet.ArenaWidth / 2f, screenHeight / 2f);
     }
 
-    /// <summary>Ported from informationSheet.py's toggle_mode(), plus the Camera re-centering character.py's caller performs alongside it.</summary>
-    public void ToggleHudMode()
-    {
-        InformationSheet.ToggleMode();
-        Camera.Lock = new Vector2(InformationSheet.ArenaWidth / 2f, ScreenHeight / 2f);
-    }
+    /// <summary>
+    /// Tab now opens/closes the weapon-stats popup instead of toggling the
+    /// sidebar's own width -- the sidebar is a single fixed width now, so
+    /// there's no ArenaWidth change here to re-center the camera for
+    /// (unlike the old HudMode toggle this replaced).
+    /// </summary>
+    public void ToggleWeaponStats() => InformationSheet.ToggleWeaponStats();
 
     public void LoadStartingEquipment() => State.SetEquipment(MetaProgression.BeginRun());
 

--- a/RotBoiRemastered/Systems/README.md
+++ b/RotBoiRemastered/Systems/README.md
@@ -42,8 +42,8 @@ port first since they were deliberately kept pygame-free in the Python original.
   semantically significant, so splitting makes the spawn/collision/
   pressure-budget logic unit testable without a GraphicsDevice.
   `GameSession` also owns Camera re-centering against
-  `InformationSheet.ArenaWidth` (constructor/`Resize`/`ResetAll`/
-  `ToggleHudMode` -- see UI/README.md) and
+  `InformationSheet.ArenaWidth` (constructor/`Resize`/`ResetAll` --
+  see UI/README.md) and
   `SelectBountyTarget()`/`BountyInfo` (ported from
   character.py's `selectBountyTarget()`, feeds InformationSheet's
   objective panel). Now that `Entities/Beaudis.cs`/`Entities/Dissonance.cs`

--- a/RotBoiRemastered/UI/InformationSheet.cs
+++ b/RotBoiRemastered/UI/InformationSheet.cs
@@ -24,7 +24,13 @@ namespace RotBoiRemastered.UI;
 /// - Camera re-centering (`bG.lockX = self.arena_width / 2`) is
 ///   GameSession's job, not this class's -- Camera isn't visible from here,
 ///   and GameSession already owns it. See GameSession.cs's constructor/
-///   Resize/ResetAll/ToggleHudMode.
+///   Resize/ResetAll.
+/// - The old compact/expanded HudMode is gone: the sidebar is a single
+///   fixed width now. The build-identity panel moved to its own arena
+///   overlay (<see cref="DrawBuildIdentityOverlay"/>) and the weapon-stats
+///   section moved into a Tab-toggled popup (<see cref="DrawWeaponStatsPopup"/>,
+///   <see cref="ToggleWeaponStats"/>) instead of always occupying sidebar
+///   space.
 /// - No implicit per-frame `_sync_layout()` self-check: <see cref="SyncLayout"/>
 ///   is called explicitly by GameSession.Resize, matching
 ///   <c>LevelingHandler.UpdateLayout</c>'s existing contract instead of
@@ -85,7 +91,6 @@ public sealed class InformationSheet
     private sealed record CrateDragSource(LootCrate Crate, int Index) : DragSource;
 
     private float _uiScale;
-    private string _mode;
     private int _screenWidth;
     private int _screenHeight;
     private int _totalLength;
@@ -99,6 +104,7 @@ public sealed class InformationSheet
     private DragSource? _draggingSource;
     private Dictionary<string, Rectangle> _equipmentSlotRects = new();
     private List<Rectangle> _lootPanelSlotRects = new();
+    private bool _weaponStatsOpen;
 
     public int ArenaWidth => _posX;
     public bool DragInProgress { get; private set; }
@@ -113,21 +119,50 @@ public sealed class InformationSheet
 
     public InformationSheet(int screenWidth, int screenHeight)
     {
-        _mode = GameProfile.Profile.HudMode;
         BuildLayout(screenWidth, screenHeight);
     }
 
     private int Px(double value) => Math.Max(1, (int)Math.Round(value * _uiScale));
+
+    /// <summary>
+    /// This sidebar is a fixed, tightly packed stack of roughly eight
+    /// panels, one of them (Recent Picks) anchored to the *bottom* of the
+    /// screen independently of how tall everything above it grows. Growing
+    /// row heights/panel heights to track TextSize was tried and made
+    /// things worse, not better: growth compounds across every stacked
+    /// panel, so even a modest setting pushed the total content well past
+    /// the screen height, and panels started colliding with *each other*
+    /// instead of just their own text overlapping. There's no room in this
+    /// specific layout to honor the full TextSize range without a much
+    /// larger reflow (variable-height rows, or making the sidebar
+    /// scrollable) -- capping the boost this sidebar's own text uses keeps
+    /// TextSize's benefit everywhere else in the game (title screen,
+    /// level-up cards, menus) while keeping this panel internally
+    /// consistent with itself. Set to UiTheme's own "LARGE" preset (one
+    /// step below "MAX") now that TextSize itself is capped at 2.0 and
+    /// preset-only -- this sidebar can absorb that much growth safely, just
+    /// not the full range.
+    /// </summary>
+    private const double MaxLocalTextBoost = 1.4;
+
+    private static double LocalTextScale() => Math.Min(UiTheme.TextScaleMultiplier(), MaxLocalTextBoost);
+
+    /// <summary>
+    /// Drop-in replacement for UiTheme.DrawText within this file: renders
+    /// through UiTheme.DrawRawText/RawFont, which skip UiTheme.Font's own
+    /// (uncapped) TextScaleMultiplier, applying LocalTextScale's capped
+    /// boost instead.
+    /// </summary>
+    private static Rectangle DrawSheetText(SpriteBatch spriteBatch, object value, double size, Color color,
+        Vector2 position, string anchor = "topleft")
+        => UiTheme.DrawRawText(spriteBatch, value, size * LocalTextScale(), color, position, anchor);
 
     private void BuildLayout(int screenWidth, int screenHeight)
     {
         _screenWidth = screenWidth;
         _screenHeight = screenHeight;
         _uiScale = UiTheme.DisplayScale(screenWidth, screenHeight);
-        double ratio = _mode == "compact" ? .15 : .24;
-        int minimum = Px(_mode == "compact" ? 220 : 300);
-        int maximum = Px(_mode == "compact" ? 320 : 440);
-        _totalLength = Math.Max(minimum, Math.Min(maximum, (int)(screenWidth * ratio)));
+        _totalLength = Math.Max(Px(220), Math.Min(Px(320), (int)(screenWidth * .15)));
         // Never consume more than 42% of a narrow display.
         _totalLength = Math.Min(_totalLength, (int)(screenWidth * .42));
         _totalHeight = screenHeight;
@@ -135,7 +170,7 @@ public sealed class InformationSheet
         _padding = Px(9);
     }
 
-    /// <summary>Call from GameSession.Resize whenever the window size changes.</summary>
+    /// <summary>Call from GameSession.Resize whenever the window size or GuiScale changes.</summary>
     public void SyncLayout(int screenWidth, int screenHeight)
     {
         float nextScale = UiTheme.DisplayScale(screenWidth, screenHeight);
@@ -143,13 +178,15 @@ public sealed class InformationSheet
             BuildLayout(screenWidth, screenHeight);
     }
 
-    public void ToggleMode()
-    {
-        _mode = _mode == "compact" ? "expanded" : "compact";
-        GameProfile.Profile.HudMode = _mode;
-        GameProfile.SaveProfile();
-        BuildLayout(_screenWidth, _screenHeight);
-    }
+    /// <summary>
+    /// TAB now opens/closes the weapon-stats popup (see DrawWeaponStatsPopup)
+    /// instead of switching the sidebar's own compact/expanded width -- the
+    /// sidebar is down to one fixed width now that the build-identity panel
+    /// moved to its own arena overlay and the weapon section moved into this
+    /// popup. Purely transient view state, not a persisted preference like
+    /// the old HudMode was, so nothing here touches GameProfile.
+    /// </summary>
+    public void ToggleWeaponStats() => _weaponStatsOpen = !_weaponStatsOpen;
 
     private Rectangle Panel(SpriteBatch spriteBatch, int y, int height, Color? accent = null, Color? fill = null)
     {
@@ -161,8 +198,8 @@ public sealed class InformationSheet
     private void Bar(SpriteBatch spriteBatch, Rectangle rect, int y, string label, double value, double maximum,
         Color color, string valueText)
     {
-        UiTheme.DrawText(spriteBatch, label, Px(9), UiTheme.Muted, new Vector2(rect.X + Px(11), y));
-        UiTheme.DrawText(spriteBatch, valueText, Px(9), UiTheme.Text, new Vector2(rect.Right - Px(11), y), "topright");
+        DrawSheetText(spriteBatch, label, Px(10), UiTheme.Muted, new Vector2(rect.X + Px(11), y));
+        DrawSheetText(spriteBatch, valueText, Px(10), UiTheme.Text, new Vector2(rect.Right - Px(11), y), "topright");
         double ratio = maximum != 0 ? value / maximum : 0;
         UiTheme.DrawProgress(spriteBatch, new Rectangle(rect.X + Px(11), y + Px(14), rect.Width - Px(22), Px(11)),
             (float)ratio, color, 10);
@@ -292,12 +329,12 @@ public sealed class InformationSheet
     private int DrawHeader(SpriteBatch spriteBatch, RunState state)
     {
         var rect = Panel(spriteBatch, _padding, Px(62), UiTheme.Cream);
-        UiTheme.DrawText(spriteBatch, $"LEVEL {state.CurrentLevel:D2}", Px(17), UiTheme.Text,
+        DrawSheetText(spriteBatch, $"LEVEL {state.CurrentLevel:D2}", Px(18), UiTheme.Text,
             new Vector2(rect.X + Px(11), rect.Y + Px(9)));
         var (pressureLabel, color, _) = Pressure(state);
-        UiTheme.DrawText(spriteBatch, pressureLabel, Px(9), color,
+        DrawSheetText(spriteBatch, pressureLabel, Px(10), color,
             new Vector2(rect.Right - Px(11), rect.Y + Px(14)), "topright");
-        UiTheme.DrawText(spriteBatch, _mode == "compact" ? "Tab: build details" : "Tab: compact view", Px(8), UiTheme.Muted,
+        DrawSheetText(spriteBatch, _weaponStatsOpen ? "Tab: close weapon stats" : "Tab: weapon stats", Px(9), UiTheme.Muted,
             new Vector2(rect.X + Px(11), rect.Bottom - Px(15)));
         return rect.Bottom + _padding;
     }
@@ -315,7 +352,7 @@ public sealed class InformationSheet
         Bar(spriteBatch, rect, rect.Y + Px(69), "NEXT PICK", state.ExpCount, state.ExpNeededForNextLevel, UiTheme.Gold,
             $"{percent:F0}%");
         if (percent >= 82)
-            UiTheme.DrawText(spriteBatch, "Next pick soon", Px(8), UiTheme.Gold,
+            DrawSheetText(spriteBatch, "Next pick soon", Px(9), UiTheme.Gold,
                 new Vector2(rect.Right - Px(11), rect.Bottom - Px(11)), "bottomright");
         return rect.Bottom + _padding;
     }
@@ -326,7 +363,7 @@ public sealed class InformationSheet
         int hubHeight = Px(140);
         int height = headerHeight + hubHeight + Px(12);
         var rect = Panel(spriteBatch, y, height, UiTheme.Border);
-        UiTheme.DrawText(spriteBatch, "EQUIPMENT", Px(9), UiTheme.Muted, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
+        DrawSheetText(spriteBatch, "EQUIPMENT", Px(10), UiTheme.Muted, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
 
         float hubX = rect.Center.X;
         float hubY = rect.Y + headerHeight + hubHeight / 2f;
@@ -364,7 +401,7 @@ public sealed class InformationSheet
                 Primitives2D.FillRect(spriteBatch, slotRect, UiTheme.Ink);
                 Primitives2D.RectOutline(spriteBatch, slotRect, UiTheme.Border, Px(2));
             }
-            UiTheme.DrawText(spriteBatch, label, Px(7), UiTheme.Muted, new Vector2(center.X, slotRect.Bottom + Px(3)), "midtop");
+            DrawSheetText(spriteBatch, label, Px(8), UiTheme.Muted, new Vector2(center.X, slotRect.Bottom + Px(3)), "midtop");
         }
         return rect.Bottom + _padding;
     }
@@ -378,7 +415,7 @@ public sealed class InformationSheet
         int slotSize = Px(38);
         int height = headerHeight + slotSize + Px(20);
         var rect = Panel(spriteBatch, y, height, UiTheme.Cream);
-        UiTheme.DrawText(spriteBatch, "NEARBY LOOT", Px(9), UiTheme.Cream, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
+        DrawSheetText(spriteBatch, "NEARBY LOOT", Px(10), UiTheme.Cream, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
 
         int gap = Px(10);
         int totalWidth = CrateSlotCount * slotSize + (CrateSlotCount - 1) * gap;
@@ -414,24 +451,33 @@ public sealed class InformationSheet
         return rect.Bottom + _padding;
     }
 
-    private int DrawBuild(SpriteBatch spriteBatch, RunState state, int y)
+    /// <summary>
+    /// Floats at the top of the arena, immediately left of the sidebar,
+    /// rather than consuming vertical space among the sidebar's stacked
+    /// panels -- moved out per user request to declutter the sidebar.
+    /// Family rows shown is now always up to 4; there's no more compact/
+    /// expanded distinction to gate it at 2.
+    /// </summary>
+    public void DrawBuildIdentityOverlay(SpriteBatch spriteBatch, RunState state)
     {
-        int height = Px(_mode == "compact" ? 106 : 134);
-        var rect = Panel(spriteBatch, y, height, UiTheme.Purple);
+        int width = Math.Max(Px(220), Math.Min(Px(280), _posX - Px(24)));
+        int height = Px(134);
+        var rect = new Rectangle(_posX - _padding - width, _padding, width, height);
+        UiTheme.DrawPanel(spriteBatch, rect, UiTheme.PanelRaised, UiTheme.Purple, shadow: 3);
         var (title, strength, caution) = BuildIdentity(state);
-        UiTheme.DrawText(spriteBatch, title, Px(14), UiTheme.Purple, new Vector2(rect.X + Px(11), rect.Y + Px(9)));
-        UiTheme.DrawText(spriteBatch, strength, Px(8), UiTheme.Text, new Vector2(rect.X + Px(11), rect.Y + Px(31)));
-        UiTheme.DrawText(spriteBatch, caution, Px(8), UiTheme.Muted, new Vector2(rect.X + Px(11), rect.Y + Px(49)));
+        DrawSheetText(spriteBatch, title, Px(15), UiTheme.Purple, new Vector2(rect.X + Px(11), rect.Y + Px(9)));
+        DrawSheetText(spriteBatch, strength, Px(9), UiTheme.Text, new Vector2(rect.X + Px(11), rect.Y + Px(31)));
+        DrawSheetText(spriteBatch, caution, Px(9), UiTheme.Muted, new Vector2(rect.X + Px(11), rect.Y + Px(49)));
         var families = FamilyCounts(state);
         if (families.Count > 0)
         {
             const int maxPips = 5;
-            int shown = Math.Min(families.Count, _mode == "compact" ? 2 : 4);
+            int shown = Math.Min(families.Count, 4);
             for (int index = 0; index < shown; index++)
             {
                 var (family, count) = families[index];
                 int rowY = rect.Y + Px(68 + index * 16);
-                UiTheme.DrawText(spriteBatch, ToTitleCase(family), Px(8), UiTheme.Muted, new Vector2(rect.X + Px(11), rowY));
+                DrawSheetText(spriteBatch, ToTitleCase(family), Px(9), UiTheme.Muted, new Vector2(rect.X + Px(11), rowY));
                 for (int pip = 0; pip < maxPips; pip++)
                 {
                     var pipRect = new Rectangle(rect.Right - Px(11 + (maxPips - pip) * 11), rowY + Px(1), Px(7), Px(7));
@@ -440,7 +486,6 @@ public sealed class InformationSheet
                 }
             }
         }
-        return rect.Bottom + _padding;
     }
 
     private static Rectangle Inflated(Rectangle rect, int dx, int dy)
@@ -455,18 +500,29 @@ public sealed class InformationSheet
         var iconRect = new Rectangle(rect.X + Px(10), y - Px(3), Px(24), Px(24));
         Primitives2D.FillRoundedRect(spriteBatch, iconRect, UiTheme.Ink, Px(3));
         StatCards.DrawStatSymbol(spriteBatch, symbol, Inflated(iconRect, -Px(4), -Px(4)), UiTheme.Cream);
-        var labelRect = UiTheme.DrawText(spriteBatch, label, Px(8), UiTheme.Muted, new Vector2(iconRect.Right + Px(7), y));
-        UiTheme.DrawText(spriteBatch, value, Px(9), UiTheme.Text, new Vector2(iconRect.Right + Px(7), y + Px(12)));
+        var labelRect = DrawSheetText(spriteBatch, label, Px(9), UiTheme.Muted, new Vector2(iconRect.Right + Px(7), y));
+        DrawSheetText(spriteBatch, value, Px(10), UiTheme.Text, new Vector2(iconRect.Right + Px(7), y + Px(12)));
         if (!string.IsNullOrEmpty(rating))
-            UiTheme.DrawText(spriteBatch, rating, Px(7), UiTheme.Green, new Vector2(rect.Right - Px(10), y + Px(1)), "topright");
+            DrawSheetText(spriteBatch, rating, Px(8), UiTheme.Green, new Vector2(rect.Right - Px(10), y + Px(1)), "topright");
         var hoverRect = new Rectangle(iconRect.X, y - Px(4), rect.Right - iconRect.X, Px(31));
         if (!string.IsNullOrEmpty(helpText) && hoverRect.Contains(mousePosition))
             _tooltip = helpText;
         return labelRect;
     }
 
-    private int DrawStats(SpriteBatch spriteBatch, RunState state, Point mousePosition, int y)
+    /// <summary>
+    /// Replaces the old always-on "YOUR WEAPON" sidebar section: this is
+    /// now an on-demand popup toggled via Tab (see ToggleWeaponStats),
+    /// centered over the arena so it doesn't compete with the sidebar for
+    /// room. Always shows every stat row -- no more compact/expanded
+    /// row-count split, since it's a deliberate look rather than
+    /// always-on real estate.
+    /// </summary>
+    public void DrawWeaponStatsPopup(SpriteBatch spriteBatch, RunState state, Point mousePosition)
     {
+        if (!_weaponStatsOpen)
+            return;
+
         double attacksPerSecond = AttacksPerSecond(state);
         var rows = new List<(string Symbol, string Label, string Value, string? Rating, string HelpText)>
         {
@@ -478,27 +534,25 @@ public sealed class InformationSheet
                 "Fractional projectile count becomes a chance to fire one bonus shot."),
             ("Crit Chance", "Critical", $"{state.CritChance * 100:F0}% chance / +{Math.Max(0, (state.CritDamage - 1) * 100):F0}% damage", null,
                 "Critical chance and the bonus damage applied when it succeeds."),
+            ("Bullet Pierce", "Piercing", PierceText(state), null,
+                "How many enemies one projectile can damage before disappearing."),
+            ("Defense", "Defense", $"Blocks {state.Defense} damage", Rating(state.Defense, 100),
+                "Flat damage removed from every incoming hit."),
+            ("Vitality", "Vitality", $"{state.Vitality} HP / sec", Rating(state.Vitality, 25),
+                "Health recovered continuously each second."),
+            ("Bullet Range", "Range", $"{state.BulletRange / Simulation.TileSize:F1} tiles", Rating(state.BulletRange, 250),
+                "Approximate projectile travel distance."),
         };
-        if (_mode == "expanded")
-        {
-            rows.Add(("Bullet Pierce", "Piercing", PierceText(state), null,
-                "How many enemies one projectile can damage before disappearing."));
-            rows.Add(("Defense", "Defense", $"Blocks {state.Defense} damage", Rating(state.Defense, 100),
-                "Flat damage removed from every incoming hit."));
-            rows.Add(("Vitality", "Vitality", $"{state.Vitality} HP / sec", Rating(state.Vitality, 25),
-                "Health recovered continuously each second."));
-            rows.Add(("Bullet Range", "Range", $"{state.BulletRange / Simulation.TileSize:F1} tiles", Rating(state.BulletRange, 250),
-                "Approximate projectile travel distance."));
-        }
+        int width = Math.Min(Px(300), Math.Max(Px(220), _posX / 3));
         int height = Px(29 + rows.Count * 31);
-        var rect = Panel(spriteBatch, y, height, UiTheme.Blue);
-        UiTheme.DrawText(spriteBatch, "YOUR WEAPON", Px(9), UiTheme.Blue, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
+        var rect = new Rectangle(_posX - _padding * 2 - width, (_totalHeight - height) / 2, width, height);
+        UiTheme.DrawPanel(spriteBatch, rect, UiTheme.PanelRaised, UiTheme.Blue, shadow: 6);
+        DrawSheetText(spriteBatch, "YOUR WEAPON", Px(10), UiTheme.Blue, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
         for (int index = 0; index < rows.Count; index++)
         {
             var row = rows[index];
             StatRow(spriteBatch, rect, rect.Y + Px(29 + index * 31), row.Symbol, row.Label, row.Value, row.Rating, row.HelpText, mousePosition);
         }
-        return rect.Bottom + _padding;
     }
 
     private int DrawObjective(SpriteBatch spriteBatch, RunState state, BountyInfo? bounty, Vector2 playerWorldPosition, int y)
@@ -507,12 +561,12 @@ public sealed class InformationSheet
         var (_, color, ratio) = Pressure(state);
         var (name, detail) = BountyDetails(bounty, state, playerWorldPosition);
         string truncatedName = name.Length > 32 ? name[..32] : name;
-        UiTheme.DrawText(spriteBatch, truncatedName, Px(11), color, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
-        UiTheme.DrawText(spriteBatch, detail, Px(8), UiTheme.Text, new Vector2(rect.X + Px(10), rect.Y + Px(29)));
+        DrawSheetText(spriteBatch, truncatedName, Px(12), color, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
+        DrawSheetText(spriteBatch, detail, Px(9), UiTheme.Text, new Vector2(rect.X + Px(10), rect.Y + Px(29)));
         UiTheme.DrawProgress(spriteBatch, new Rectangle(rect.X + Px(10), rect.Y + Px(47), rect.Width - Px(20), Px(8)),
             (float)ratio, color, 8);
         var (level, milestone) = NextMilestone(state);
-        UiTheme.DrawText(spriteBatch, $"Next: level {level} • {milestone}", Px(7), UiTheme.Muted,
+        DrawSheetText(spriteBatch, $"Next: level {level} • {milestone}", Px(8), UiTheme.Muted,
             new Vector2(rect.X + Px(10), rect.Bottom - Px(9)), "bottomleft");
         return rect.Bottom + _padding;
     }
@@ -523,7 +577,7 @@ public sealed class InformationSheet
         int height = Math.Max(Px(76), Math.Min(Px(112), available));
         int y = _totalHeight - height - _padding;
         var rect = Panel(spriteBatch, y, height, UiTheme.Cream, UiTheme.Panel);
-        UiTheme.DrawText(spriteBatch, "RECENT PICKS", Px(8), UiTheme.Muted, new Vector2(rect.X + Px(10), rect.Y + Px(7)));
+        DrawSheetText(spriteBatch, "RECENT PICKS", Px(9), UiTheme.Muted, new Vector2(rect.X + Px(10), rect.Y + Px(7)));
         int tableY = rect.Y + Px(25);
         Primitives2D.FillRect(spriteBatch,
             new Rectangle(rect.X + Px(7), tableY, rect.Width - Px(14), rect.Bottom - tableY - Px(7)), UiTheme.Ink);
@@ -535,7 +589,7 @@ public sealed class InformationSheet
             : state.UpgradeHistory;
         if (history.Count == 0)
         {
-            UiTheme.DrawText(spriteBatch, "Your upgrade cards will collect here.", Px(7), UiTheme.Muted,
+            DrawSheetText(spriteBatch, "Your upgrade cards will collect here.", Px(8), UiTheme.Muted,
                 new Vector2(rect.Center.X, tableY + (rect.Bottom - tableY) / 2f), "center");
             return;
         }
@@ -576,7 +630,7 @@ public sealed class InformationSheet
         if (string.IsNullOrEmpty(_tooltip))
             return;
         int width = Math.Min(Px(250), (int)(_screenWidth * .24));
-        var font = UiTheme.Font(Px(8));
+        var font = UiTheme.RawFont(Px(9) * LocalTextScale());
         var words = _tooltip.Split(' ');
         var lines = new List<string>();
         string line = "";
@@ -594,12 +648,12 @@ public sealed class InformationSheet
             }
         }
         lines.Add(line);
-        var rect = new Rectangle(mousePosition.X - width - Px(10), mousePosition.Y + Px(10), width, Px(14 + lines.Count * 13));
+        var rect = new Rectangle(mousePosition.X - width - Px(10), mousePosition.Y + Px(10), width, Px(15 + lines.Count * 14));
         rect = ClampToBounds(rect, new Rectangle(_posX, 0, _totalLength, _totalHeight));
         UiTheme.DrawPanel(spriteBatch, rect, UiTheme.PanelRaised, UiTheme.Cream, shadow: 4);
         for (int index = 0; index < lines.Count; index++)
-            UiTheme.DrawText(spriteBatch, lines[index], Px(8), UiTheme.Text,
-                new Vector2(rect.X + Px(9), rect.Y + Px(7 + index * 13)));
+            DrawSheetText(spriteBatch, lines[index], Px(9), UiTheme.Text,
+                new Vector2(rect.X + Px(9), rect.Y + Px(8 + index * 14)));
     }
 
     private void DrawItemTooltip(SpriteBatch spriteBatch, Point mousePosition, ItemDrop item)
@@ -621,9 +675,9 @@ public sealed class InformationSheet
         var symbolInner = symbolRect;
         symbolInner.Inflate(-Px(7), -Px(7));
         ItemCards.DrawItemSymbol(spriteBatch, item.SlotType, symbolInner, UiTheme.Ink, item.Definition.VisualKind);
-        UiTheme.DrawText(spriteBatch, item.Name.ToUpperInvariant(), Px(14), UiTheme.Text,
+        DrawSheetText(spriteBatch, item.Name.ToUpperInvariant(), Px(15), UiTheme.Text,
             new Vector2(symbolRect.Right + Px(11), rect.Y + Px(14)));
-        UiTheme.DrawText(spriteBatch, $"{item.Rarity.ToUpperInvariant()}  //  {item.SlotType.ToUpperInvariant()}", Px(8), rarity,
+        DrawSheetText(spriteBatch, $"{item.Rarity.ToUpperInvariant()}  //  {item.SlotType.ToUpperInvariant()}", Px(9), rarity,
             new Vector2(symbolRect.Right + Px(11), rect.Y + Px(40)));
 
         int y = rect.Y + headerHeight;
@@ -633,22 +687,22 @@ public sealed class InformationSheet
             Primitives2D.FillRect(spriteBatch, row, UiTheme.Panel);
             var icon = new Rectangle(row.X + Px(6), row.Y + Px(4), Px(27), Px(27));
             StatCards.DrawStatSymbol(spriteBatch, effect.Stat, icon, rarity);
-            UiTheme.DrawText(spriteBatch, effect.Stat.ToUpperInvariant(), Px(8), UiTheme.Muted,
+            DrawSheetText(spriteBatch, effect.Stat.ToUpperInvariant(), Px(9), UiTheme.Muted,
                 new Vector2(icon.Right + Px(8), row.Center.Y), "midleft");
             Color valueColor = effect.IsBeneficial ? UiTheme.Green : UiTheme.Red;
-            UiTheme.DrawText(spriteBatch, effect.DisplayValue, Px(15), valueColor,
+            DrawSheetText(spriteBatch, effect.DisplayValue, Px(16), valueColor,
                 new Vector2(row.Right - Px(8), row.Center.Y), "midright");
             y += rowHeight;
         }
         foreach (var (kind, chance) in statuses)
         {
             double scaled = chance * Items.RarityPower(item.Rarity) * 100;
-            UiTheme.DrawText(spriteBatch, $"✦  {kind.ToUpperInvariant()}  {scaled:0}% ON HIT", Px(10), UiTheme.Green,
+            DrawSheetText(spriteBatch, $"✦  {kind.ToUpperInvariant()}  {scaled:0}% ON HIT", Px(11), UiTheme.Green,
                 new Vector2(rect.X + Px(16), y + Px(5)));
             y += Px(30);
         }
         Primitives2D.Line(spriteBatch, new Vector2(rect.X + Px(12), y), new Vector2(rect.Right - Px(12), y), UiTheme.Border, 1);
-        UiTheme.DrawText(spriteBatch, $"“{item.Definition.Description}”", Px(9), UiTheme.Cream,
+        DrawSheetText(spriteBatch, $"“{item.Definition.Description}”", Px(10), UiTheme.Cream,
             new Vector2(rect.X + Px(15), y + Px(12)));
     }
 
@@ -665,16 +719,18 @@ public sealed class InformationSheet
         Primitives2D.FillRect(spriteBatch, new Rectangle(_posX, 0, _totalLength, _totalHeight), UiTheme.Void);
         Primitives2D.FillRect(spriteBatch, new Rectangle(_posX, 0, Px(6), _totalHeight), UiTheme.Ink);
 
+        DrawBuildIdentityOverlay(spriteBatch, state);
+
         int y = DrawHeader(spriteBatch, state);
         y = DrawStatus(spriteBatch, state, y);
         y = DrawInventory(spriteBatch, state, mousePosition, y);
         if (state.NearbyCrate is not null && y + Px(70) < _totalHeight - Px(82))
             y = DrawLootPanel(spriteBatch, state, mousePosition, y);
-        y = DrawBuild(spriteBatch, state, y);
-        y = DrawStats(spriteBatch, state, mousePosition, y);
-        if (_mode == "compact" && y + Px(90) < _totalHeight - Px(82))
+        if (y + Px(90) < _totalHeight - Px(82))
             y = DrawObjective(spriteBatch, state, currentBounty, playerWorldPosition, y);
         DrawRecentTable(spriteBatch, state, mousePosition, y);
+
+        DrawWeaponStatsPopup(spriteBatch, state, mousePosition);
 
         if (_draggingItem is not null)
         {

--- a/RotBoiRemastered/UI/LevelingHandler.cs
+++ b/RotBoiRemastered/UI/LevelingHandler.cs
@@ -163,14 +163,15 @@ public sealed class LevelingHandler
             float rarityWidth = UiTheme.Font(_tileSize * .23).MeasureString(card.Rarity.ToUpperInvariant()).X;
             UiTheme.DrawTag(spriteBatch, card.Rarity,
                 new Vector2(visualRect.Right - Px(22) - rarityWidth, visualRect.Y + Px(29)), accent, _tileSize * .23);
+            float textWidth = visualRect.Width - Px(36);
             UiTheme.DrawText(spriteBatch, card.Definition.Category.ToUpperInvariant() + " CARD", _tileSize * 0.24, UiTheme.Muted,
                 new Vector2(visualRect.Center.X, visualRect.Y + _tileSize * 1.55f), "center");
-            UiTheme.DrawText(spriteBatch, card.Name, _tileSize * 0.58, UiTheme.Text,
-                new Vector2(visualRect.Center.X, visualRect.Y + _tileSize * 2.15f), "center");
+            UiTheme.DrawWrappedText(spriteBatch, card.Name, _tileSize * 0.58, UiTheme.Text,
+                new Vector2(visualRect.Center.X, visualRect.Y + _tileSize * 2.15f), textWidth);
             Primitives2D.Line(spriteBatch, new Vector2(visualRect.X + Px(28), visualRect.Y + _tileSize * 2.72f),
                 new Vector2(visualRect.Right - Px(28), visualRect.Y + _tileSize * 2.72f), accent, (int)Px(2));
-            UiTheme.DrawText(spriteBatch, card.Definition.Description, _tileSize * 0.38, UiTheme.Text,
-                new Vector2(visualRect.Center.X, visualRect.Center.Y - _tileSize * 0.2f), "center");
+            UiTheme.DrawWrappedText(spriteBatch, card.Definition.Description, _tileSize * 0.38, UiTheme.Text,
+                new Vector2(visualRect.Center.X, visualRect.Center.Y - _tileSize * 0.2f), textWidth);
 
             string mode = card.MathType == "additive" ? "Flat bonus" : "Scaling bonus";
             float modeWidth = UiTheme.Font(_tileSize * .2).MeasureString(mode.ToUpperInvariant()).X;

--- a/RotBoiRemastered/UI/Menus.cs
+++ b/RotBoiRemastered/UI/Menus.cs
@@ -216,9 +216,10 @@ public sealed class Menus
             var textSizeRect = new Rectangle(sliderX, (int)(bodyTop + 51 * scale), sliderWidth, rowHeight);
             Slider(spriteBatch, "text_size", textSizeRect, "TEXT SIZE", $"{GameProfile.Profile.TextSize * 100:0}%",
                 GameProfile.Profile.TextSize, UiTheme.MinTextScale, UiTheme.MaxTextScale, mousePosition, UiTheme.Gold);
+            int guiLevel = ClosestIndex(UiTheme.GuiScaleLevels, GameProfile.Profile.GuiScale);
             var guiRect = new Rectangle(sliderX, textSizeRect.Bottom + rowGap, sliderWidth, rowHeight);
-            Slider(spriteBatch, "gui_scale", guiRect, "GUI SCALE", $"{GameProfile.Profile.GuiScale * 100:0}%",
-                GameProfile.Profile.GuiScale, UiTheme.MinGuiScale, UiTheme.MaxGuiScale, mousePosition, UiTheme.Blue);
+            Button(spriteBatch, "gui_scale", guiRect,
+                $"GUI SCALE  //  {UiTheme.GuiScaleLabels[guiLevel]}", mousePosition, mouseDown, UiTheme.Blue);
             var damageRect = new Rectangle(sliderX, guiRect.Bottom + rowGap, sliderWidth, rowHeight);
             Slider(spriteBatch, "damage_text_size", damageRect, "DAMAGE TEXT SIZE", $"{GameProfile.Profile.DamageTextSize * 100:0}%",
                 GameProfile.Profile.DamageTextSize, UiTheme.MinDamageTextScale, UiTheme.MaxDamageTextScale, mousePosition, UiTheme.Red);
@@ -256,7 +257,7 @@ public sealed class Menus
                 new Vector2(settings.X + 14 * scale, mouseY));
         }
 
-        UiTheme.DrawText(spriteBatch, "TAB toggles HUD details during play", 9 * scale, UiTheme.Muted,
+        UiTheme.DrawText(spriteBatch, "TAB shows weapon stats during play", 9 * scale, UiTheme.Muted,
             new Vector2(screenWidth / 2f, screenHeight * .82f), "center");
     }
 
@@ -324,6 +325,12 @@ public sealed class Menus
             }
             if (Activated("fullscreen", mousePosition, mousePressed))
                 GameProfile.Toggle("Fullscreen");
+            if (Activated("gui_scale", mousePosition, mousePressed))
+            {
+                int idx = ClosestIndex(UiTheme.GuiScaleLevels, GameProfile.Profile.GuiScale);
+                GameProfile.Profile.GuiScale = UiTheme.GuiScaleLevels[(idx + 1) % UiTheme.GuiScaleLevels.Count];
+                GameProfile.SaveProfile();
+            }
             if (mouseDown)
             {
                 if (_activeSlider is null)
@@ -331,9 +338,8 @@ public sealed class Menus
                 if (_activeSlider is not null && _sliders.TryGetValue(_activeSlider, out var slider))
                 {
                     double value = SliderValue(slider.Track, mousePosition.X, slider.Min, slider.Max);
-                    if (_activeSlider == "text_size") GameProfile.Profile.TextSize = Math.Round(value, 2);
-                    if (_activeSlider == "gui_scale") GameProfile.Profile.GuiScale = Math.Round(value, 2);
                     if (_activeSlider == "damage_text_size") GameProfile.Profile.DamageTextSize = Math.Round(value, 2);
+                    if (_activeSlider == "text_size") GameProfile.Profile.TextSize = Math.Round(value, 2);
                     _sliderDirty = true;
                 }
             }

--- a/RotBoiRemastered/UI/README.md
+++ b/RotBoiRemastered/UI/README.md
@@ -103,8 +103,15 @@ HUD, menus, and shared drawing/theme helpers. Mapping from the Python source:
   Python's `_sync_layout`/`toggle_mode` set `bG.lockX = self.arena_width / 2`
   directly (informationSheet.py owning a background.py global). Camera
   isn't visible from `InformationSheet`, and `GameSession` already owns it,
-  so `GameSession`'s constructor/`Resize`/`ResetAll`/`ToggleHudMode` do the
-  re-centering using `InformationSheet.ArenaWidth` instead.
+  so `GameSession`'s constructor/`Resize`/`ResetAll` do the re-centering
+  using `InformationSheet.ArenaWidth` instead.
+- **The old compact/expanded `HudMode` is gone.** The sidebar is a single
+  fixed width now; the build-identity panel moved to its own arena overlay
+  (`DrawBuildIdentityOverlay`) and the weapon-stats section moved into a
+  Tab-toggled popup (`DrawWeaponStatsPopup`/`ToggleWeaponStats`) instead of
+  always occupying sidebar space. `GameSession.ToggleWeaponStats` (renamed
+  from `ToggleHudMode`) just forwards to it now -- no more `ArenaWidth`
+  change to re-center the camera for.
 - **No implicit per-frame `_sync_layout()` self-check** -- `SyncLayout` is
   called explicitly from `GameSession.Resize`, matching
   `LevelingHandler.UpdateLayout`'s existing contract instead of re-deriving

--- a/RotBoiRemastered/UI/TitleScreen.cs
+++ b/RotBoiRemastered/UI/TitleScreen.cs
@@ -50,23 +50,52 @@ public sealed class TitleScreen
         DrawGrid(spriteBatch, screenWidth, screenHeight);
 
         float scale = Math.Min(screenWidth, screenHeight);
-        float uiScale = UiTheme.DisplayScale(screenWidth, screenHeight);
+        // Text sizes below (scale * .095, etc.) already pick up TextSize
+        // through UiTheme.Font internally. Layout (button/panel widths,
+        // heights, gaps) only ever scaled with GuiScale via uiScale --
+        // DrawButton's own shrink-to-fit loop has a floor (raw size 9) that
+        // still renders far too wide once a high TextSize multiplies it, so
+        // without growing the boxes too, the five path buttons overlapped
+        // each other well before any single label's text could shrink
+        // enough to fit. uiScale now folds in the same growth-only factor
+        // InformationSheet.TextGrowthFactor uses, so layout keeps pace with
+        // whatever TextSize the text itself is already rendering at. The
+        // extra headroom factor is capped well below MaxTextScale (2.0) --
+        // DisplayScale already folds in GuiScale (up to 1.3x), and at max
+        // GuiScale *and* max TextSize the two multiplied together (2.6x)
+        // pushed the whole stack past the bottom of the screen. Capping
+        // the headroom side of that product keeps both sliders maxed out
+        // simultaneously from overflowing.
+        float uiScale = UiTheme.DisplayScale(screenWidth, screenHeight) * (float)Math.Max(1.0, Math.Min(1.3, UiTheme.TextScaleMultiplier()));
         float contentWidth = Math.Min(screenWidth * .68f, 980 * uiScale);
         float left = (screenWidth - contentWidth) / 2f;
-        UiTheme.DrawText(spriteBatch, "ROTBOI", scale * .095, UiTheme.Text, new Vector2(screenWidth / 2f, screenHeight * .12f), "midtop");
-        UiTheme.DrawText(spriteBatch, "R E M A S T E R E D", scale * .026, UiTheme.Cream, new Vector2(screenWidth / 2f, screenHeight * .245f), "midtop");
-        UiTheme.DrawText(spriteBatch, "CHOOSE WHAT THE ROT REMEMBERS.", scale * .019, UiTheme.Muted, new Vector2(screenWidth / 2f, screenHeight * .305f), "midtop");
+        // Free-floating title/subtitle/tagline text has no container to grow
+        // with it, so a high TextSize can make one line's rendered height
+        // alone exceed the fixed gap to the next fraction-of-screen-height
+        // anchor below it. Math.Max(originalFraction, previousBottom + gap)
+        // falls back to that measured bottom only once it would actually
+        // overlap -- at default TextSize this is always the original
+        // fraction (unchanged from before), so nothing shifts for anyone
+        // who hasn't touched the slider. Capped on the high end too (at
+        // roughly double its floor) so the cascade itself can't compound
+        // into an overflow no matter how large uiScale gets.
+        float gap = Math.Min(8 * uiScale, screenHeight * .018f);
+        var titleRect = UiTheme.DrawText(spriteBatch, "ROTBOI", scale * .095, UiTheme.Text, new Vector2(screenWidth / 2f, screenHeight * .12f), "midtop");
+        float subtitleY = Math.Max(screenHeight * .245f, titleRect.Bottom + gap);
+        var subtitleRect = UiTheme.DrawText(spriteBatch, "R E M A S T E R E D", scale * .026, UiTheme.Cream, new Vector2(screenWidth / 2f, subtitleY), "midtop");
+        float taglineY = Math.Max(screenHeight * .305f, subtitleRect.Bottom + gap);
+        var taglineRect = UiTheme.DrawText(spriteBatch, "CHOOSE WHAT THE ROT REMEMBERS.", scale * .019, UiTheme.Muted, new Vector2(screenWidth / 2f, taglineY), "midtop");
 
-        float selectorY = screenHeight * .365f;
-        float gap = 8 * uiScale;
+        float selectorY = Math.Max(screenHeight * .365f, taglineRect.Bottom + gap * 2);
         var paths = GamePaths.Paths;
         float selectorWidth = (contentWidth - gap * (paths.Count - 1)) / paths.Count;
+        float selectorHeight = Math.Min(Math.Max(50 * uiScale, scale * .058f), scale * .085f);
         _pathButtons.Clear();
         for (int index = 0; index < paths.Count; index++)
         {
             var path = paths[index];
             var rect = new Rectangle((int)(left + index * (selectorWidth + gap)), (int)selectorY,
-                (int)selectorWidth, (int)Math.Max(50 * uiScale, scale * .058f));
+                (int)selectorWidth, (int)selectorHeight);
             bool isSelected = path.Key == GamePaths.Selected().Key;
             UiTheme.DrawButton(spriteBatch, rect, path.Title, mousePosition, mouseDown, true,
                 isSelected ? path.Accent : UiTheme.Border, null, (int)(scale * .014f));
@@ -74,15 +103,19 @@ public sealed class TitleScreen
         }
 
         var selected = GamePaths.Selected();
-        UiTheme.DrawText(spriteBatch, $"{selected.Subtitle}  //  {selected.Description}", scale * .013, selected.Accent,
-            new Vector2(screenWidth / 2f, screenHeight * .455f), "midtop");
-        _playButton = new Rectangle((int)(left + contentWidth * .27f), (int)(screenHeight * .495f),
-            (int)(contentWidth * .46f), (int)Math.Max(54 * uiScale, scale * .064f));
+        float descriptionY = Math.Max(screenHeight * .455f, selectorY + selectorHeight + gap * 2);
+        var descriptionRect = UiTheme.DrawText(spriteBatch, $"{selected.Subtitle}  //  {selected.Description}", scale * .013, selected.Accent,
+            new Vector2(screenWidth / 2f, descriptionY), "midtop");
+        float playButtonY = Math.Max(screenHeight * .495f, descriptionRect.Bottom + gap * 2);
+        float playButtonHeight = Math.Min(Math.Max(54 * uiScale, scale * .064f), scale * .095f);
+        _playButton = new Rectangle((int)(left + contentWidth * .27f), (int)playButtonY,
+            (int)(contentWidth * .46f), (int)playButtonHeight);
         UiTheme.DrawButton(spriteBatch, _playButton, $"ENTER {selected.Title}", mousePosition, mouseDown, true,
             selected.Accent, "SPACE", (int)(scale * .019f));
 
-        _soulButton = new Rectangle((int)(left + contentWidth * .18f), (int)(screenHeight * .585f),
-            (int)(contentWidth * .30f), (int)Math.Max(42 * uiScale, scale * .052f));
+        float soulButtonY = Math.Max(screenHeight * .585f, playButtonY + playButtonHeight + gap * 2);
+        _soulButton = new Rectangle((int)(left + contentWidth * .18f), (int)soulButtonY,
+            (int)(contentWidth * .30f), (int)Math.Min(Math.Max(42 * uiScale, scale * .052f), scale * .078f));
         UiTheme.DrawButton(spriteBatch, _soulButton, "ENTER THE SOUL", mousePosition, mouseDown, true,
             UiTheme.Purple, "F", (int)(scale * .014f));
         _settingsButton = new Rectangle((int)(left + contentWidth * .52f), _soulButton.Y,
@@ -90,8 +123,9 @@ public sealed class TitleScreen
         UiTheme.DrawButton(spriteBatch, _settingsButton, "SETTINGS", mousePosition, mouseDown, true,
             UiTheme.Blue, null, (int)(scale * .014f));
 
-        var controlsRect = new Rectangle((int)left, (int)(screenHeight * .665f), (int)contentWidth,
-            (int)Math.Max(116 * uiScale, screenHeight * .15f));
+        float controlsY = Math.Max(screenHeight * .665f, _soulButton.Bottom + gap * 2);
+        var controlsRect = new Rectangle((int)left, (int)controlsY, (int)contentWidth,
+            (int)Math.Min(Math.Max(116 * uiScale, screenHeight * .15f), screenHeight * .21f));
         UiTheme.DrawPanel(spriteBatch, controlsRect, UiTheme.Panel, UiTheme.Border, shadow: 6);
         UiTheme.DrawText(spriteBatch, "FIELD MANUAL", scale * .018, UiTheme.Text,
             new Vector2(controlsRect.X + 18 * uiScale, controlsRect.Y + 14 * uiScale));

--- a/RotBoiRemastered/UI/UiTheme.cs
+++ b/RotBoiRemastered/UI/UiTheme.cs
@@ -51,12 +51,27 @@ public static class UiTheme
     public const int ReferenceHeight = 1080;
     public const float MinDisplayScale = .6f;
     public const float MaxDisplayScale = 2.4f;
-    public const double MinTextScale = .75;
-    public const double MaxTextScale = 3.0;
-    public const double MinGuiScale = .75;
-    public const double MaxGuiScale = 1.8;
+    public const double MinTextScale = .85;
+    public const double MaxTextScale = 2.0;
+    public const double MinGuiScale = .85;
+    public const double MaxGuiScale = 1.3;
     public const double MinDamageTextScale = .45;
     public const double MaxDamageTextScale = 2.0;
+
+    /// <summary>
+    /// Fixed presets rather than a free-form slider for GuiScale -- see
+    /// Menus.cs's OPTIONS tab. It used to be a continuous slider up to
+    /// 1.8x; at that extreme the pause/title screens' fixed-pixel button
+    /// offsets started running off-screen or overlapping themselves.
+    /// Capping the range and only exposing a handful of pre-checked steps
+    /// keeps every screen usable at every selectable value, at the cost of
+    /// not being able to dial in an arbitrary in-between percentage.
+    /// TextSize stays a plain slider (capped at MaxTextScale) -- its sidebar
+    /// overlap problem was solved instead by InformationSheet's own capped
+    /// local text scale (see DrawSheetText/MaxLocalTextBoost there).
+    /// </summary>
+    public static readonly IReadOnlyList<double> GuiScaleLevels = new[] { .85, 1.0, 1.15, 1.3 };
+    public static readonly IReadOnlyList<string> GuiScaleLabels = new[] { "SMALL", "NORMAL", "LARGE", "MAX" };
 
     private static FontSystem? _fontSystem;
 
@@ -134,6 +149,56 @@ public static class UiTheme
             font.DrawText(spriteBatch, text, new Vector2(rect.X + 1, rect.Y), drawColor);
         font.DrawText(spriteBatch, text, new Vector2(rect.X, rect.Y), drawColor);
         return rect;
+    }
+
+    /// <summary>
+    /// Greedy word-wrap at the given font size: the fewest lines whose
+    /// measured width all fit within maxWidth. A single word wider than
+    /// maxWidth on its own still gets its own (overflowing) line rather than
+    /// being split mid-word. Text-size-aware callers (card names/
+    /// descriptions) need this because a fixed-width container plus a
+    /// user-adjustable TextSize multiplier means the same string can outgrow
+    /// its box at any font size, not just a handful of unusually long ones.
+    /// </summary>
+    public static List<string> WrapLines(string text, double fontSize, float maxWidth)
+    {
+        var font = Font(fontSize);
+        var words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var lines = new List<string>();
+        string current = "";
+        foreach (var word in words)
+        {
+            string candidate = current.Length == 0 ? word : $"{current} {word}";
+            if (current.Length > 0 && font.MeasureString(candidate).X > maxWidth)
+            {
+                lines.Add(current);
+                current = word;
+            }
+            else
+            {
+                current = candidate;
+            }
+        }
+        if (current.Length > 0 || lines.Count == 0)
+            lines.Add(current);
+        return lines;
+    }
+
+    /// <summary>
+    /// Draws WrapLines' output centered horizontally on `center.X`, stacked
+    /// vertically so the whole block stays centered on `center.Y` -- a
+    /// single-line result lands at exactly `center`, matching plain
+    /// DrawText's anchor: "center" behavior so wrapping never shifts
+    /// already-short text that never needed it.
+    /// </summary>
+    public static void DrawWrappedText(SpriteBatch spriteBatch, string text, double fontSize, Color color,
+        Vector2 center, float maxWidth, bool bold = false)
+    {
+        var lines = WrapLines(text, fontSize, maxWidth);
+        float lineHeight = Font(fontSize).MeasureString("Ag").Y;
+        float startY = center.Y - lineHeight * lines.Count / 2f + lineHeight / 2f;
+        for (int index = 0; index < lines.Count; index++)
+            DrawText(spriteBatch, lines[index], fontSize, color, new Vector2(center.X, startY + index * lineHeight), "center", bold);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Level-up cards and the in-game information panel no longer overflow/overlap as TEXT SIZE and GUI SCALE increase; TEXT SIZE is a slider (capped at 200%), GUI SCALE is a preset cycle-button (capped at max).
- Information panel decluttered: the "FRESH START" build-identity summary moved to its own overlay at the top of the arena, and the "YOUR WEAPON" stats section moved into a Tab-toggled popup instead of always occupying sidebar space. Sidebar base font sizes bumped up for readability.
- Title screen no longer overflows the bottom of the screen when TEXT SIZE and GUI SCALE are both maxed out at the same time.

## Test plan
- [x] `dotnet build` (main project) — clean
- [x] `dotnet test` — 419/419 passing
- [ ] Manual check in-game: level-up cards, information panel (Tab popup, build overlay), title screen at various TEXT SIZE / GUI SCALE combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)