### PR TITLE
Add an in-run stash, clarify next-run gear selection, and fix reticle/crate render-order bugs

### DIFF
--- a/RotBoiRemastered.Tests/Systems/MetaProgressionTests.cs
+++ b/RotBoiRemastered.Tests/Systems/MetaProgressionTests.cs
@@ -67,6 +67,27 @@ public class MetaProgressionTests : IDisposable
     }
 
     [Fact]
+    public void RecordExtraction_IncludesStashedItemsAlongsideEquipment()
+    {
+        var state = new RunState();
+        state.Inventory[0] = Items.Deserialize(new StoredItemData("Iron Dagger", "Common"));
+
+        MetaProgression.RecordExtraction(state, "sound", completed: false);
+
+        Assert.Contains(GameProfile.Profile.ExtractedRuns[0].Items, item => item.Name == "Iron Dagger");
+    }
+
+    [Fact]
+    public void ClearStartingLoadoutSlot_RemovesAssignedSlot()
+    {
+        GameProfile.Profile.StartingLoadout["weapon"] = new StoredItemData("Iron Dagger", "Epic");
+
+        MetaProgression.ClearStartingLoadoutSlot("weapon");
+
+        Assert.False(GameProfile.Profile.StartingLoadout.ContainsKey("weapon"));
+    }
+
+    [Fact]
     public void TransferFromExtractedRun_RespectsTenSlotCapacity()
     {
         GameProfile.Profile.Storage.AddRange(Enumerable.Range(0, MetaProgression.StorageCapacity)

--- a/RotBoiRemastered.Tests/Systems/RunStateTests.cs
+++ b/RotBoiRemastered.Tests/Systems/RunStateTests.cs
@@ -2,10 +2,27 @@ using RotBoiRemastered.Systems;
 
 namespace RotBoiRemastered.Tests.Systems;
 
-/// <summary>Ported from characterStats.py's default/reset values and combarinoPlayerStats' stat-combination math.</summary>
+/// <summary>
+/// Ported from characterStats.py's default/reset values and
+/// combarinoPlayerStats' stat-combination math.
+///
+/// RunState.Reset() calls MetaProgression.ApplySkills(this), which reads
+/// GameProfile.Profile.SkillLevels -- and GameProfile.Profile is process-wide
+/// static state seeded from whatever the developer's real %APPDATA% save
+/// happens to contain. Every test here asserts exact stat values assuming no
+/// purchased skills are in play, so this needs the same reset-to-defaults
+/// isolation as MetaProgressionTests/UiThemeTests, or these go flaky/fail
+/// outright the moment a live save has actually purchased a skill.
+/// </summary>
 [Collection("GameProfileState")]
-public class RunStateTests
+public class RunStateTests : IDisposable
 {
+    private readonly GameProfileData _originalProfile = GameProfile.Profile;
+
+    public RunStateTests() => GameProfile.Profile = new GameProfileData();
+
+    public void Dispose() => GameProfile.Profile = _originalProfile;
+
     [Fact]
     public void Reset_EstablishesExpectedDefaults()
     {
@@ -18,6 +35,8 @@ public class RunStateTests
         Assert.Empty(state.BulletHolster);
         Assert.Equal(5, state.Equipment.Count);
         Assert.All(state.Equipment.Values, Assert.Null);
+        Assert.Equal(8, state.Inventory.Count);
+        Assert.All(state.Inventory, Assert.Null);
     }
 
     [Fact]

--- a/RotBoiRemastered/Core/RotBoiGame.cs
+++ b/RotBoiRemastered/Core/RotBoiGame.cs
@@ -513,6 +513,7 @@ public class RotBoiGame : Game
         session.DrawBountyIndicator(_spriteBatch);
         session.DrawInformationSheet(_spriteBatch, InputState.MousePosition);
         session.HandleInformationSheetDrag(InputState.MousePosition, InputState.MouseDown, InputState.MousePressed);
+        session.DrawAimReticle(_spriteBatch, InputState.MousePosition);
         _spriteBatch.End();
     }
 

--- a/RotBoiRemastered/Entities/LootCrate.cs
+++ b/RotBoiRemastered/Entities/LootCrate.cs
@@ -38,12 +38,22 @@ public sealed class LootCrate
         return UiTheme.RarityColors.TryGetValue(best.Rarity, out var color) ? color : UiTheme.Border;
     }
 
+    /// <summary>
+    /// This draws in its own unscaled SpriteBatch pass (see
+    /// GameSession.DrawLootCrates's scissor-clipped Begin/End, which has no
+    /// zoom transform matrix like the main entity batch does) -- so unlike
+    /// bullets/enemies/the player, which get zoom for free from that matrix,
+    /// position and size both need Camera.ApplyZoom/Zoom applied by hand here,
+    /// or crates stay a fixed screen position/size while everything around
+    /// them zooms, reading as if they're floating independently of the world.
+    /// </summary>
     public void Draw(SpriteBatch spriteBatch, Camera camera, Vector2 playerWorldPosition, Vector2 screenShake)
     {
-        Vector2 screenPosition = camera.WorldToScreen(new Vector2(WorldX, WorldY), playerWorldPosition, screenShake);
-        var rect = new Rectangle((int)screenPosition.X, (int)screenPosition.Y, (int)Size, (int)Size);
+        Vector2 screenPosition = camera.ApplyZoom(camera.WorldToScreen(new Vector2(WorldX, WorldY), playerWorldPosition, screenShake));
+        float size = Size * camera.Zoom;
+        var rect = new Rectangle((int)screenPosition.X, (int)screenPosition.Y, (int)size, (int)size);
         Color accent = Tint();
-        int border = Math.Max(2, (int)(Size * 0.08f));
+        int border = Math.Max(2, (int)(size * 0.08f));
 
         var shadowRect = new Rectangle(rect.X + 4, (int)(rect.Bottom - rect.Height * 0.18f), rect.Width, (int)(rect.Height * 0.18f));
         Primitives2D.FillEllipse(spriteBatch, shadowRect, UiTheme.Shadow);
@@ -51,7 +61,7 @@ public sealed class LootCrate
         Primitives2D.RectOutline(spriteBatch, rect, accent, border);
 
         float lidY = rect.Y + rect.Height * 0.35f;
-        Primitives2D.Line(spriteBatch, new Vector2(rect.X, lidY), new Vector2(rect.Right, lidY), accent, Math.Max(2, (int)(Size * 0.06f)));
-        Primitives2D.Line(spriteBatch, new Vector2(rect.Center.X, rect.Y), new Vector2(rect.Center.X, rect.Bottom), accent, Math.Max(1, (int)(Size * 0.04f)));
+        Primitives2D.Line(spriteBatch, new Vector2(rect.X, lidY), new Vector2(rect.Right, lidY), accent, Math.Max(2, (int)(size * 0.06f)));
+        Primitives2D.Line(spriteBatch, new Vector2(rect.Center.X, rect.Y), new Vector2(rect.Center.X, rect.Bottom), accent, Math.Max(1, (int)(size * 0.04f)));
     }
 }

--- a/RotBoiRemastered/Systems/GameSession.cs
+++ b/RotBoiRemastered/Systems/GameSession.cs
@@ -954,7 +954,8 @@ public sealed class GameSession
         foreach (var crate in State.LootCrateList)
         {
             var screen = Camera.ApplyZoom(Camera.WorldToScreen(new Vector2(crate.WorldX, crate.WorldY), PlayerWorldCenter, ScreenShake));
-            var rect = new Rectangle((int)screen.X, (int)screen.Y, (int)crate.Size, (int)crate.Size);
+            int zoomedSize = (int)(crate.Size * Camera.Zoom);
+            var rect = new Rectangle((int)screen.X, (int)screen.Y, zoomedSize, zoomedSize);
             if (rect.Intersects(new Rectangle(0, 0, InformationSheet.ArenaWidth, ScreenHeight)))
                 crate.Draw(spriteBatch, Camera, PlayerWorldCenter, ScreenShake);
         }
@@ -1088,17 +1089,23 @@ public sealed class GameSession
         UiTheme.DrawText(spriteBatch, "BOUNTY", 9, UiTheme.Red, labelPosition, "center");
     }
 
-    /// <summary>Draws the combat-only overlays layered above the arena and below the sidebar.</summary>
+    /// <summary>
+    /// Draws the combat-only overlays layered above the arena and below the
+    /// sidebar. The aim reticle is drawn separately (see
+    /// <see cref="DrawAimReticle"/>) and later in the frame -- it needs to sit
+    /// above the sidebar's weapon-stats popup (Tab), which otherwise painted
+    /// over the reticle since that popup is centered within the arena, right
+    /// where the reticle draws too.
+    /// </summary>
     public void DrawCombatOverlays(SpriteBatch spriteBatch, Point mousePosition)
     {
-        DrawAimReticle(spriteBatch, mousePosition);
         DrawBossHealthBar(spriteBatch);
         DrawLowHealthWarning(spriteBatch);
         DrawRunCompleteBanner(spriteBatch);
         DrawTutorialHint(spriteBatch);
     }
 
-    private void DrawAimReticle(SpriteBatch spriteBatch, Point mousePosition)
+    public void DrawAimReticle(SpriteBatch spriteBatch, Point mousePosition)
     {
         if (mousePosition.X < 0 || mousePosition.X >= InformationSheet.ArenaWidth
             || mousePosition.Y < 0 || mousePosition.Y >= ScreenHeight || InformationSheet.DragInProgress)

--- a/RotBoiRemastered/Systems/MetaProgression.cs
+++ b/RotBoiRemastered/Systems/MetaProgression.cs
@@ -143,7 +143,8 @@ public static class MetaProgression
             Level = state.CurrentLevel,
             Kills = state.NumOfEnemiesKilled,
             Seconds = state.RunTimeSeconds,
-            Items = state.Equipment.Values.Where(item => item is not null).Cast<ItemDrop>().Select(Items.Serialize).ToList(),
+            Items = state.Equipment.Values.Concat(state.Inventory)
+                .Where(item => item is not null).Cast<ItemDrop>().Select(Items.Serialize).ToList(),
         };
         GameProfile.Profile.ExtractedRuns.Insert(0, run);
         if (GameProfile.Profile.ExtractedRuns.Count > 10)
@@ -189,5 +190,12 @@ public static class MetaProgression
         GameProfile.Profile.StartingLoadout[target] = stored;
         GameProfile.SaveProfile();
         return true;
+    }
+
+    /// <summary>Un-assigns a slot from the next run's loadout -- the Soul's "NEXT RUN" preview strip's click-to-remove.</summary>
+    public static void ClearStartingLoadoutSlot(string slot)
+    {
+        GameProfile.Profile.StartingLoadout.Remove(slot);
+        GameProfile.SaveProfile();
     }
 }

--- a/RotBoiRemastered/Systems/RunState.cs
+++ b/RotBoiRemastered/Systems/RunState.cs
@@ -239,6 +239,8 @@ public sealed class RunState
     public List<EnemyProjectile> EnemyProjectileHolster { get; } = new();
     public List<LootCrate> LootCrateList { get; } = new();
     public Dictionary<string, ItemDrop?> Equipment { get; private set; } = new();
+    /// <summary>Eight general-purpose hoarding slots -- unlike Equipment, never read by CombinePlayerStats, so contents never affect stats.</summary>
+    public List<ItemDrop?> Inventory { get; private set; } = new();
     public LootCrate? NearbyCrate { get; set; }
 
     public object? ActiveBoss { get; set; }
@@ -339,6 +341,7 @@ public sealed class RunState
         {
             ["weapon"] = null, ["armor"] = null, ["ring"] = null, ["accessory_1"] = null, ["accessory_2"] = null,
         };
+        Inventory = Enumerable.Repeat<ItemDrop?>(null, 8).ToList();
         ActiveBoss = null;
         BeaudisEncounterStarted = false;
         BeaudisDefeated = false;

--- a/RotBoiRemastered/UI/InformationSheet.cs
+++ b/RotBoiRemastered/UI/InformationSheet.cs
@@ -86,9 +86,12 @@ public sealed class InformationSheet
 
     public const int CrateSlotCount = 4;
 
+    public const int InventorySlotCount = 8;
+
     private abstract record DragSource;
     private sealed record EquipmentDragSource(string Key) : DragSource;
     private sealed record CrateDragSource(LootCrate Crate, int Index) : DragSource;
+    private sealed record InventoryDragSource(int Index) : DragSource;
 
     private float _uiScale;
     private int _screenWidth;
@@ -104,6 +107,7 @@ public sealed class InformationSheet
     private DragSource? _draggingSource;
     private Dictionary<string, Rectangle> _equipmentSlotRects = new();
     private List<Rectangle> _lootPanelSlotRects = new();
+    private List<Rectangle> _inventorySlotRects = new();
     private bool _weaponStatsOpen;
 
     public int ArenaWidth => _posX;
@@ -402,6 +406,51 @@ public sealed class InformationSheet
                 Primitives2D.RectOutline(spriteBatch, slotRect, UiTheme.Border, Px(2));
             }
             DrawSheetText(spriteBatch, label, Px(8), UiTheme.Muted, new Vector2(center.X, slotRect.Bottom + Px(3)), "midtop");
+        }
+        return rect.Bottom + _padding;
+    }
+
+    /// <summary>
+    /// Eight general-purpose hoarding slots, directly below the equipment
+    /// hub. Unlike equipment, a stash slot accepts any item regardless of
+    /// SlotType (see ResolveDrop) and never contributes to stats (see
+    /// RunState.Inventory's doc comment) -- it's purely for carrying extra
+    /// loot toward extraction without committing to equip it.
+    /// </summary>
+    private int DrawStash(SpriteBatch spriteBatch, RunState state, Point mousePosition, int y)
+    {
+        const int columns = 4;
+        int rows = (InventorySlotCount + columns - 1) / columns;
+        int headerHeight = Px(24);
+        int slotSize = Px(38);
+        int gap = Px(8);
+        int height = headerHeight + rows * slotSize + (rows - 1) * gap + Px(12);
+        var rect = Panel(spriteBatch, y, height, UiTheme.Border);
+        DrawSheetText(spriteBatch, "STASH", Px(10), UiTheme.Muted, new Vector2(rect.X + Px(10), rect.Y + Px(8)));
+
+        int totalWidth = columns * slotSize + (columns - 1) * gap;
+        float startX = rect.Center.X - totalWidth / 2f;
+        int startY = rect.Y + headerHeight;
+        _inventorySlotRects = new List<Rectangle>();
+        for (int index = 0; index < InventorySlotCount; index++)
+        {
+            int column = index % columns, row = index / columns;
+            var slotRect = new Rectangle((int)(startX + column * (slotSize + gap)), startY + row * (slotSize + gap), slotSize, slotSize);
+            _inventorySlotRects.Add(slotRect);
+            var item = state.Inventory[index];
+            bool draggingThis = _draggingSource is InventoryDragSource inv && inv.Index == index;
+            if (item is not null && !draggingThis)
+            {
+                bool hovered = slotRect.Contains(mousePosition);
+                ItemCards.DrawItemCard(spriteBatch, slotRect, item, hovered);
+                if (hovered)
+                    _tooltipItem = item;
+            }
+            else
+            {
+                Primitives2D.FillRect(spriteBatch, slotRect, UiTheme.Ink);
+                Primitives2D.RectOutline(spriteBatch, slotRect, UiTheme.Border, Px(2));
+            }
         }
         return rect.Bottom + _padding;
     }
@@ -724,6 +773,7 @@ public sealed class InformationSheet
         int y = DrawHeader(spriteBatch, state);
         y = DrawStatus(spriteBatch, state, y);
         y = DrawInventory(spriteBatch, state, mousePosition, y);
+        y = DrawStash(spriteBatch, state, mousePosition, y);
         if (state.NearbyCrate is not null && y + Px(70) < _totalHeight - Px(82))
             y = DrawLootPanel(spriteBatch, state, mousePosition, y);
         if (y + Px(90) < _totalHeight - Px(82))
@@ -775,6 +825,16 @@ public sealed class InformationSheet
                     return;
                 }
             }
+            for (int index = 0; index < _inventorySlotRects.Count; index++)
+            {
+                if (_inventorySlotRects[index].Contains(mousePosition) && state.Inventory[index] is not null)
+                {
+                    _draggingItem = state.Inventory[index];
+                    _draggingSource = new InventoryDragSource(index);
+                    DragInProgress = true;
+                    return;
+                }
+            }
             return;
         }
 
@@ -818,20 +878,48 @@ public sealed class InformationSheet
                 var displaced = state.Equipment[targetKey];
                 state.Equipment[targetKey] = item;
                 GameProfile.DiscoverItem(item.Name);
-                if (displaced is not null)
-                {
-                    crateSource.Crate.Items[crateSource.Index] = displaced;
-                }
-                else
-                {
-                    crateSource.Crate.Items.RemoveAt(crateSource.Index);
-                    if (crateSource.Crate.Items.Count == 0)
-                    {
-                        state.LootCrateList.Remove(crateSource.Crate);
-                        if (ReferenceEquals(state.NearbyCrate, crateSource.Crate))
-                            state.NearbyCrate = null;
-                    }
-                }
+                ReturnDisplacedToCrate(state, crateSource, displaced);
+            }
+            else if (source is InventoryDragSource equipFromStash)
+            {
+                // Swap: works whether the equipment slot is occupied or empty.
+                (state.Inventory[equipFromStash.Index], state.Equipment[targetKey]) =
+                    (state.Equipment[targetKey], state.Inventory[equipFromStash.Index]);
+            }
+            return;
+        }
+
+        int targetInventoryIndex = -1;
+        for (int index = 0; index < _inventorySlotRects.Count; index++)
+        {
+            if (_inventorySlotRects[index].Contains(mousePosition))
+            {
+                targetInventoryIndex = index;
+                break;
+            }
+        }
+
+        if (targetInventoryIndex >= 0)
+        {
+            // Unlike equipment slots, a stash slot has no SlotType restriction -- it can hold anything.
+            if (source is InventoryDragSource stashSource)
+            {
+                if (stashSource.Index == targetInventoryIndex)
+                    return; // released back over its own slot -- treat as a cancelled drag
+                (state.Inventory[stashSource.Index], state.Inventory[targetInventoryIndex]) =
+                    (state.Inventory[targetInventoryIndex], state.Inventory[stashSource.Index]);
+            }
+            else if (source is EquipmentDragSource stashFromEquipment)
+            {
+                (state.Equipment[stashFromEquipment.Key], state.Inventory[targetInventoryIndex]) =
+                    (state.Inventory[targetInventoryIndex], state.Equipment[stashFromEquipment.Key]);
+            }
+            else if (source is CrateDragSource crateSource)
+            {
+                var displaced = state.Inventory[targetInventoryIndex];
+                state.Inventory[targetInventoryIndex] = item;
+                GameProfile.DiscoverItem(item.Name);
+                ReturnDisplacedToCrate(state, crateSource, displaced);
             }
             return;
         }
@@ -839,12 +927,40 @@ public sealed class InformationSheet
         if (source is EquipmentDragSource unequip)
         {
             state.Equipment[unequip.Key] = null;
-            var crate = state.NearbyCrate;
-            if (crate is not null && crate.Items.Count < CrateSlotCount)
-                crate.Items.Add(item);
-            else
-                state.LootCrateList.Add(new LootCrate(playerWorldPosition.X, playerWorldPosition.Y, new[] { item }));
+            DropIntoWorld(state, playerWorldPosition, item);
+        }
+        else if (source is InventoryDragSource unstash)
+        {
+            state.Inventory[unstash.Index] = null;
+            DropIntoWorld(state, playerWorldPosition, item);
         }
         // source is CrateDragSource and the drop target was invalid: no-op, item stays put.
+    }
+
+    private static void ReturnDisplacedToCrate(RunState state, CrateDragSource crateSource, ItemDrop? displaced)
+    {
+        if (displaced is not null)
+        {
+            crateSource.Crate.Items[crateSource.Index] = displaced;
+        }
+        else
+        {
+            crateSource.Crate.Items.RemoveAt(crateSource.Index);
+            if (crateSource.Crate.Items.Count == 0)
+            {
+                state.LootCrateList.Remove(crateSource.Crate);
+                if (ReferenceEquals(state.NearbyCrate, crateSource.Crate))
+                    state.NearbyCrate = null;
+            }
+        }
+    }
+
+    private static void DropIntoWorld(RunState state, Vector2 playerWorldPosition, ItemDrop item)
+    {
+        var crate = state.NearbyCrate;
+        if (crate is not null && crate.Items.Count < CrateSlotCount)
+            crate.Items.Add(item);
+        else
+            state.LootCrateList.Add(new LootCrate(playerWorldPosition.X, playerWorldPosition.Y, new[] { item }));
     }
 }

--- a/RotBoiRemastered/UI/SoulHub.cs
+++ b/RotBoiRemastered/UI/SoulHub.cs
@@ -116,6 +116,7 @@ public sealed class SoulHub
                 MetaProgression.TransferRunItemToStorage(parts[1], int.Parse(parts[2]));
             }
             else if (key.StartsWith("stored:")) MetaProgression.SelectStorageItem(int.Parse(key[7..]));
+            else if (key.StartsWith("loadout:")) MetaProgression.ClearStartingLoadoutSlot(key[8..]);
             else if (key.StartsWith("cosmetic:"))
             {
                 var parts = key.Split(':');
@@ -203,25 +204,52 @@ public sealed class SoulHub
 
     private static string TimeLabel(double seconds) => $"{(int)seconds / 60:00}:{(int)seconds % 60:00}";
 
+    private static readonly (string Label, string Slot)[] NextRunSlots =
+    {
+        ("WEAPON", "weapon"), ("ARMOR", "armor"), ("RING", "ring"), ("ACC 1", "accessory_1"), ("ACC 2", "accessory_2"),
+    };
+
     private void DrawStorage(SpriteBatch spriteBatch, Rectangle panel, Point mouse)
     {
         UiTheme.DrawText(spriteBatch, "EXTRACTION CHEST", 24, UiTheme.Text, new Vector2(panel.X + 24, panel.Y + 18));
-        UiTheme.DrawText(spriteBatch, $"PERMANENT STORAGE  {GameProfile.Profile.Storage.Count}/{MetaProgression.StorageCapacity}  //  CLICK STORED ITEMS TO PREPARE NEXT RUN",
+        UiTheme.DrawText(spriteBatch, $"PERMANENT STORAGE  {GameProfile.Profile.Storage.Count}/{MetaProgression.StorageCapacity}  //  CLICK A STORED ITEM TO STAGE IT BELOW  //  CLICK A STAGED SLOT TO REMOVE IT",
             9, UiTheme.Gold, new Vector2(panel.X + 26, panel.Y + 53));
         int slotSize = 44, gap = 8;
         for (int index = 0; index < MetaProgression.StorageCapacity; index++)
         {
             var rect = new Rectangle(panel.X + 26 + index * (slotSize + gap), panel.Y + 76, slotSize, slotSize);
             Primitives2D.FillRect(spriteBatch, rect, UiTheme.Ink);
-            Primitives2D.RectOutline(spriteBatch, rect, UiTheme.Border, 2);
+            bool promised = index < GameProfile.Profile.Storage.Count
+                && GameProfile.Profile.StartingLoadout.Values.Contains(GameProfile.Profile.Storage[index]);
+            Primitives2D.RectOutline(spriteBatch, rect, promised ? UiTheme.Cream : UiTheme.Border, promised ? 3 : 2);
             if (index >= GameProfile.Profile.Storage.Count) continue;
             var drop = Items.Deserialize(GameProfile.Profile.Storage[index]);
             if (drop is null) continue;
             ItemCards.DrawItemCard(spriteBatch, rect, drop, rect.Contains(mouse));
             _targets[$"stored:{index}"] = rect;
-            if (rect.Contains(mouse)) _tooltip = $"{drop.Rarity} {drop.Name}  //  Click to prepare for the next run.";
+            if (rect.Contains(mouse))
+                _tooltip = promised
+                    ? $"{drop.Rarity} {drop.Name}  //  Staged for the next run."
+                    : $"{drop.Rarity} {drop.Name}  //  Click to prepare for the next run.";
         }
-        int y = panel.Y + 142;
+
+        UiTheme.DrawText(spriteBatch, "NEXT RUN LOADOUT", 11, UiTheme.Cream, new Vector2(panel.X + 26, panel.Y + 132));
+        for (int index = 0; index < NextRunSlots.Length; index++)
+        {
+            var (label, slot) = NextRunSlots[index];
+            var rect = new Rectangle(panel.X + 26 + index * (slotSize + gap), panel.Y + 152, slotSize, slotSize);
+            Primitives2D.FillRect(spriteBatch, rect, UiTheme.Ink);
+            var stored = GameProfile.Profile.StartingLoadout.GetValueOrDefault(slot);
+            var staged = stored is null ? null : Items.Deserialize(stored);
+            Primitives2D.RectOutline(spriteBatch, rect, staged is not null ? UiTheme.Cream : UiTheme.Border, staged is not null ? 3 : 2);
+            UiTheme.DrawText(spriteBatch, label, 7, UiTheme.Muted, new Vector2(rect.Center.X, rect.Bottom + 3), "midtop");
+            if (staged is null) continue;
+            ItemCards.DrawItemCard(spriteBatch, rect, staged, rect.Contains(mouse));
+            _targets[$"loadout:{slot}"] = rect;
+            if (rect.Contains(mouse)) _tooltip = $"{staged.Rarity} {staged.Name}  //  Click to remove from the next run.";
+        }
+
+        int y = panel.Y + 204;
         if (GameProfile.Profile.ExtractedRuns.Count == 0)
         {
             UiTheme.DrawText(spriteBatch, "No extracted runs yet", 22, UiTheme.Muted, new Vector2(panel.Center.X, panel.Center.Y), "center");


### PR DESCRIPTION
## Summary
- New 8-slot in-run stash below the equipment hub for hoarding loot without affecting stats -- drag items in/out from equipment or crates, contents travel home through extraction the same way equipped gear does.
- Soul's "EXTRACTION CHEST" now highlights items staged for your next run and shows a "NEXT RUN LOADOUT" preview strip (click a filled slot to un-stage it), so it's clear what you're bringing with you.
- Fixed the aim reticle rendering underneath the Tab weapon-stats popup -- it now draws last so it always stays on top.
- Fixed loot crates staying a fixed screen size/position while zooming (they render in their own unscaled batch, so camera zoom now gets applied to them by hand, matching how the bounty indicator already does it).
- Fixed `RunStateTests` never isolating itself from `GameProfile.Profile` (seeded from the real `%APPDATA%` save at process start), which made its exact stat assertions fail once that save had a purchased skill in it.

## Test plan
- [x] `dotnet build` -- clean
- [x] `dotnet test` -- 421/421 passing
- [ ] Manual check in-game: drag items between stash/equipment/crate, extract a run with stashed items and confirm they show up in the Soul; stage/unstage next-run gear via both the storage grid and the new strip; open the Tab popup and confirm the cursor stays visible over it; zoom in/out and confirm crates scale and track position correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)