### PR TITLE
Replace extraction staging with a persistent carried loadout, and reuse the gameplay sidebar/drag system for the Soul's Vault

### DIFF
--- a/RotBoiRemastered.Tests/Systems/GameSessionTests.cs
+++ b/RotBoiRemastered.Tests/Systems/GameSessionTests.cs
@@ -32,6 +32,25 @@ public class GameSessionTests
     }
 
     [Fact]
+    public void Constructor_LoadsCarriedEquipmentFromProfile()
+    {
+        var original = GameProfile.Profile;
+        try
+        {
+            GameProfile.Profile = new GameProfileData();
+            GameProfile.Profile.CarriedEquipment["weapon"] = new StoredItemData("Iron Dagger", "Epic");
+
+            var session = new GameSession(Battleground.GenerateSound(), 1280, 720);
+
+            Assert.Equal("Iron Dagger", session.State.Equipment["weapon"]!.Name);
+        }
+        finally
+        {
+            GameProfile.Profile = original;
+        }
+    }
+
+    [Fact]
     public void HandleBulletCreation_FiresWhenAutoFireAndCooldownReady()
     {
         var session = MakeSession();

--- a/RotBoiRemastered.Tests/Systems/MetaProgressionTests.cs
+++ b/RotBoiRemastered.Tests/Systems/MetaProgressionTests.cs
@@ -67,52 +67,28 @@ public class MetaProgressionTests : IDisposable
     }
 
     [Fact]
-    public void RecordExtraction_IncludesStashedItemsAlongsideEquipment()
+    public void SyncCarriedItems_RoundTripsEquipmentAndInventoryIntoProfile()
     {
         var state = new RunState();
-        state.Inventory[0] = Items.Deserialize(new StoredItemData("Iron Dagger", "Common"));
+        state.Equipment["weapon"] = Items.Deserialize(new StoredItemData("Iron Dagger", "Epic"));
+        state.Inventory[0] = Items.Deserialize(new StoredItemData("Rusty Sword", "Common"));
 
-        MetaProgression.RecordExtraction(state, "sound", completed: false);
+        MetaProgression.SyncCarriedItems(state);
 
-        Assert.Contains(GameProfile.Profile.ExtractedRuns[0].Items, item => item.Name == "Iron Dagger");
+        Assert.Equal("Iron Dagger", GameProfile.Profile.CarriedEquipment["weapon"].Name);
+        Assert.Equal("Rusty Sword", GameProfile.Profile.CarriedInventory[0]!.Name);
+        Assert.All(GameProfile.Profile.CarriedInventory.Skip(1), Assert.Null);
     }
 
     [Fact]
-    public void ClearStartingLoadoutSlot_RemovesAssignedSlot()
+    public void ClearCarriedItems_EmptiesEquipmentAndInventory()
     {
-        GameProfile.Profile.StartingLoadout["weapon"] = new StoredItemData("Iron Dagger", "Epic");
+        GameProfile.Profile.CarriedEquipment["weapon"] = new StoredItemData("Iron Dagger", "Epic");
+        GameProfile.Profile.CarriedInventory[0] = new StoredItemData("Rusty Sword", "Common");
 
-        MetaProgression.ClearStartingLoadoutSlot("weapon");
+        MetaProgression.ClearCarriedItems();
 
-        Assert.False(GameProfile.Profile.StartingLoadout.ContainsKey("weapon"));
-    }
-
-    [Fact]
-    public void TransferFromExtractedRun_RespectsTenSlotCapacity()
-    {
-        GameProfile.Profile.Storage.AddRange(Enumerable.Range(0, MetaProgression.StorageCapacity)
-            .Select(_ => new StoredItemData("Iron Dagger", "Common")));
-        GameProfile.Profile.ExtractedRuns.Add(new ExtractedRunData
-        {
-            Items = new List<StoredItemData> { new("Rusty Sword", "Rare") },
-        });
-
-        var run = GameProfile.Profile.ExtractedRuns[0];
-        Assert.False(MetaProgression.TransferRunItemToStorage(run.Id, 0));
-        Assert.Single(run.Items);
-    }
-
-    [Fact]
-    public void BeginRun_WithdrawsSelectedStoredCopy()
-    {
-        var stored = new StoredItemData("Iron Dagger", "Epic");
-        GameProfile.Profile.Storage.Add(stored);
-        GameProfile.Profile.StartingLoadout["weapon"] = stored;
-
-        var equipment = MetaProgression.BeginRun();
-
-        Assert.Equal("Iron Dagger", equipment["weapon"]!.Name);
-        Assert.Empty(GameProfile.Profile.Storage);
-        Assert.Empty(GameProfile.Profile.StartingLoadout);
+        Assert.Empty(GameProfile.Profile.CarriedEquipment);
+        Assert.All(GameProfile.Profile.CarriedInventory, Assert.Null);
     }
 }

--- a/RotBoiRemastered/Core/RotBoiGame.cs
+++ b/RotBoiRemastered/Core/RotBoiGame.cs
@@ -285,7 +285,6 @@ public class RotBoiGame : Game
                     _session = new GameSession(battleground, GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height);
                 else
                     _session.ResetAll(battleground);
-                _session.LoadStartingEquipment();
                 State = GameState.GameRun;
                 break;
             }
@@ -349,6 +348,7 @@ public class RotBoiGame : Game
         bool fatalHit = session.HurtPlayer();
         if (fatalHit)
         {
+            MetaProgression.ClearCarriedItems();
             State = GameState.Results;
             return;
         }
@@ -393,6 +393,9 @@ public class RotBoiGame : Game
                 break;
             case MenuAction.Restart:
                 if (_session is null) break;
+                // A plain restart didn't kill the player, so under "persist unless you
+                // die" it carries the loadout forward same as extracting/completing would.
+                MetaProgression.SyncCarriedItems(_session.State);
                 GameProfile.SaveProfile();
                 _session.ResetAll(GamePaths.ActivateSelected());
                 State = GameState.GameRun;
@@ -405,6 +408,7 @@ public class RotBoiGame : Game
                 if (_session is null) break;
                 _session.State.RunOutcome = "EXTRACTED";
                 MetaProgression.RecordExtraction(_session.State, GamePaths.Selected().Key, completed: false);
+                MetaProgression.SyncCarriedItems(_session.State);
                 GameProfile.RecordRun(_session.State.CurrentLevel, _session.State.NumOfEnemiesKilled);
                 State = GameState.Results;
                 break;
@@ -440,14 +444,14 @@ public class RotBoiGame : Game
         var session = _session!;
         session.MovePlayer(Keybinds.Held("move_left"), Keybinds.Held("move_right"), Keybinds.Held("move_up"), Keybinds.Held("move_down"),
             Keybinds.Pressed("dash") || InputState.ControllerDashPressed, InputState.ControllerMove);
-        _soulHub.HandleInput(session, InputState.KeysPressed, InputState.MousePosition, InputState.MousePressed);
+        _soulHub.HandleInput(session, InputState.KeysPressed, InputState.MousePosition, InputState.MouseDown, InputState.MousePressed);
         if (_soulHub.OverlayOpen)
             return;
         var aim = new Vector2(InputState.MousePosition.X, InputState.MousePosition.Y);
         bool controllerFiring = InputState.ControllerAim.LengthSquared() > .0625f;
         if (controllerFiring)
             aim = session.Camera.Lock + InputState.ControllerAim * GraphicsDevice.Viewport.Width;
-        session.HandleBulletCreation(aim, InputState.MouseDown, dragInProgress: false, controllerFiring: controllerFiring);
+        session.HandleBulletCreation(aim, InputState.MouseDown, session.InformationSheet.DragInProgress, controllerFiring: controllerFiring);
         session.UpdateBullets();
         _soulHub.Update(session, gameTime.ElapsedGameTime.TotalSeconds);
     }

--- a/RotBoiRemastered/Systems/GameProfile.cs
+++ b/RotBoiRemastered/Systems/GameProfile.cs
@@ -45,8 +45,22 @@ public sealed class GameProfileData
     public Dictionary<string, int> SkillLevels { get; set; } = new();
     public Dictionary<string, long> QuestProgress { get; set; } = new();
     public List<string> CompletedQuests { get; set; } = new();
+    /// <summary>The Vault -- safe, permanent storage. Capacity-limited (see MetaProgression.StorageCapacity).</summary>
     public List<StoredItemData> Storage { get; set; } = new();
-    public Dictionary<string, StoredItemData> StartingLoadout { get; set; } = new();
+    /// <summary>
+    /// What's currently carried into runs, mirroring RunState.Equipment (slot key -> item,
+    /// absence = empty). Synced from the live run whenever it ends without dying
+    /// (MetaProgression.SyncCarriedItems), cleared on death (ClearCarriedItems), and loaded
+    /// back into a fresh RunState by GameSession.LoadCarriedItems.
+    /// </summary>
+    public Dictionary<string, StoredItemData> CarriedEquipment { get; set; } = new();
+    /// <summary>
+    /// Mirrors RunState.Inventory (8 slots, nullable) the same way CarriedEquipment mirrors
+    /// Equipment. Pre-padded to 8 nulls here (matching RunState.Inventory's own Reset())
+    /// rather than relying solely on GameProfile.Normalize() to pad it, so a freshly
+    /// constructed GameProfileData is already index-safe without going through LoadProfile.
+    /// </summary>
+    public List<StoredItemData?> CarriedInventory { get; set; } = Enumerable.Repeat<StoredItemData?>(null, 8).ToList();
     public List<ExtractedRunData> ExtractedRuns { get; set; } = new();
     public List<string> DiscoveredItems { get; set; } = new();
     public Dictionary<string, int> PathMastery { get; set; } = new();
@@ -63,7 +77,6 @@ public sealed class ExtractedRunData
     public int Level { get; set; }
     public int Kills { get; set; }
     public double Seconds { get; set; }
-    public List<StoredItemData> Items { get; set; } = new();
 }
 
 /// <summary>
@@ -152,12 +165,21 @@ public static class GameProfile
         profile.QuestProgress ??= new();
         profile.CompletedQuests ??= new();
         profile.Storage ??= new();
-        profile.StartingLoadout ??= new();
+        profile.CarriedEquipment ??= new();
+        profile.CarriedInventory ??= new();
+        // GameSession.LoadCarriedItems indexes this by position up to InventorySlotCount,
+        // same as RunState.Inventory itself -- pad/truncate so a missing/short/corrupt
+        // save (or the very first launch, where it's just an empty list) can't index out
+        // of range.
+        if (profile.CarriedInventory.Count < InformationSheet.InventorySlotCount)
+            profile.CarriedInventory.AddRange(Enumerable.Repeat<StoredItemData?>(null,
+                InformationSheet.InventorySlotCount - profile.CarriedInventory.Count));
+        else if (profile.CarriedInventory.Count > InformationSheet.InventorySlotCount)
+            profile.CarriedInventory.RemoveRange(InformationSheet.InventorySlotCount,
+                profile.CarriedInventory.Count - InformationSheet.InventorySlotCount);
         profile.ExtractedRuns ??= new();
         profile.DiscoveredItems ??= new();
         profile.PathMastery ??= new();
-        foreach (var run in profile.ExtractedRuns)
-            run.Items ??= new();
     }
 
     public static bool SaveProfile(string? path = null)

--- a/RotBoiRemastered/Systems/GameSession.cs
+++ b/RotBoiRemastered/Systems/GameSession.cs
@@ -79,6 +79,7 @@ public sealed class GameSession
         LevelingHandler = new LevelingHandler(screenWidth, screenHeight, rng);
         InformationSheet = new InformationSheet(screenWidth, screenHeight);
         Camera.Lock = new Vector2(InformationSheet.ArenaWidth / 2f, screenHeight / 2f);
+        LoadCarriedItems();
     }
 
     /// <summary>Ported from character.py's resetAllStats() (the parts not already covered by RunState.Reset()).</summary>
@@ -94,6 +95,7 @@ public sealed class GameSession
         InformationSheet = new InformationSheet(ScreenWidth, ScreenHeight);
         Camera.Lock = new Vector2(InformationSheet.ArenaWidth / 2f, ScreenHeight / 2f);
         _activeBossKey = null;
+        LoadCarriedItems();
     }
 
     public void Resize(int screenWidth, int screenHeight)
@@ -113,9 +115,24 @@ public sealed class GameSession
     /// </summary>
     public void ToggleWeaponStats() => InformationSheet.ToggleWeaponStats();
 
-    public void LoadStartingEquipment() => State.SetEquipment(MetaProgression.BeginRun());
-
-    public void LoadPreviewEquipment() => State.SetEquipment(MetaProgression.PreviewLoadout());
+    /// <summary>
+    /// Loads whatever's currently carried (GameProfile.Profile.CarriedEquipment/
+    /// CarriedInventory) into this session -- called by the constructor and by
+    /// ResetAll, so every run/Soul-visit start picks up your persistent loadout
+    /// with no separate call needed at each call site. See
+    /// MetaProgression.SyncCarriedItems/ClearCarriedItems for the write side.
+    /// </summary>
+    public void LoadCarriedItems()
+    {
+        var equipment = new Dictionary<string, ItemDrop?>();
+        foreach (var (slot, stored) in GameProfile.Profile.CarriedEquipment)
+            equipment[slot] = Items.Deserialize(stored);
+        State.SetEquipment(equipment);
+        for (int index = 0; index < State.Inventory.Count; index++)
+            State.Inventory[index] = index < GameProfile.Profile.CarriedInventory.Count
+                ? Items.Deserialize(GameProfile.Profile.CarriedInventory[index])
+                : null;
+    }
 
     /// <summary>
     /// Ported from character.py's drawBackground(). Bakes/draws the arena's
@@ -732,6 +749,7 @@ public sealed class GameSession
                     State.GameCompleted = true;
                     State.RunOutcome = "RUN COMPLETE";
                     MetaProgression.RecordExtraction(State, GamePaths.Selected().Key, completed: true);
+                    MetaProgression.SyncCarriedItems(State);
                     GameProfile.RecordRun(State.CurrentLevel, State.NumOfEnemiesKilled, completed: true);
                 }
                 State.ActiveBoss = null;
@@ -1247,6 +1265,14 @@ public sealed class GameSession
     /// <summary>Convenience wrapper: call once per frame, after <see cref="DrawInformationSheet"/>.</summary>
     public void HandleInformationSheetDrag(Point mousePosition, bool mouseDown, bool mousePressed) =>
         InformationSheet.HandleDrag(State, PlayerWorldCenter, mousePosition, mouseDown, mousePressed);
+
+    /// <summary>The Soul's counterpart to DrawInformationSheet/HandleInformationSheetDrag -- see InformationSheet.DrawCarriedLoadout's doc comment.</summary>
+    public void DrawCarriedLoadout(SpriteBatch spriteBatch, Point mousePosition) =>
+        InformationSheet.DrawCarriedLoadout(spriteBatch, State, mousePosition);
+
+    /// <summary>Call once per frame, after <see cref="DrawCarriedLoadout"/>, while in the Soul.</summary>
+    public void HandleCarriedLoadoutDrag(Point mousePosition, bool mouseDown, bool mousePressed, IReadOnlyList<Rectangle> vaultSlotRects) =>
+        InformationSheet.HandleDrag(State, PlayerWorldCenter, mousePosition, mouseDown, mousePressed, vaultSlotRects, allowWorldDrop: false);
 
     // ----- Health -----
 

--- a/RotBoiRemastered/Systems/MetaProgression.cs
+++ b/RotBoiRemastered/Systems/MetaProgression.cs
@@ -104,34 +104,32 @@ public static class MetaProgression
         }
     }
 
-    public static Dictionary<string, ItemDrop?> EmptyEquipment() => new()
+    /// <summary>
+    /// Writes the currently carried loadout (Equipment + Inventory) back to the
+    /// profile so it survives past this run -- call whenever a run ends
+    /// *without* dying (extract, complete, or a plain restart from the pause
+    /// menu). GameSession.LoadCarriedItems is the inverse, reading this back
+    /// into a fresh RunState.
+    /// </summary>
+    public static void SyncCarriedItems(RunState state)
     {
-        ["weapon"] = null, ["armor"] = null, ["ring"] = null, ["accessory_1"] = null, ["accessory_2"] = null,
-    };
-
-    public static Dictionary<string, ItemDrop?> BeginRun()
-    {
-        var equipment = EmptyEquipment();
-        foreach (var (slot, serialized) in GameProfile.Profile.StartingLoadout.ToArray())
-        {
-            int index = GameProfile.Profile.Storage.FindIndex(stored => stored == serialized);
-            if (!equipment.ContainsKey(slot) || index < 0)
-                continue;
-            equipment[slot] = Items.Deserialize(GameProfile.Profile.Storage[index]);
-            GameProfile.Profile.Storage.RemoveAt(index);
-        }
-        GameProfile.Profile.StartingLoadout.Clear();
+        GameProfile.Profile.CarriedEquipment = state.Equipment
+            .Where(pair => pair.Value is not null)
+            .ToDictionary(pair => pair.Key, pair => Items.Serialize(pair.Value!));
+        GameProfile.Profile.CarriedInventory = state.Inventory
+            .Select(item => item is null ? null : Items.Serialize(item))
+            .ToList();
         GameProfile.SaveProfile();
-        return equipment;
     }
 
-    public static Dictionary<string, ItemDrop?> PreviewLoadout()
+    /// <summary>The one and only "you died" path -- everything carried (not vaulted) is lost.</summary>
+    public static void ClearCarriedItems()
     {
-        var equipment = EmptyEquipment();
-        foreach (var (slot, serialized) in GameProfile.Profile.StartingLoadout)
-            if (equipment.ContainsKey(slot))
-                equipment[slot] = Items.Deserialize(serialized);
-        return equipment;
+        GameProfile.Profile.CarriedEquipment.Clear();
+        // Matches RunState.Inventory's fixed 8 slots (see its Reset()) -- kept as a literal
+        // here too rather than a cross-layer reference to the UI's InventorySlotCount const.
+        GameProfile.Profile.CarriedInventory = Enumerable.Repeat<StoredItemData?>(null, 8).ToList();
+        GameProfile.SaveProfile();
     }
 
     public static void RecordExtraction(RunState state, string path, bool completed)
@@ -143,8 +141,6 @@ public static class MetaProgression
             Level = state.CurrentLevel,
             Kills = state.NumOfEnemiesKilled,
             Seconds = state.RunTimeSeconds,
-            Items = state.Equipment.Values.Concat(state.Inventory)
-                .Where(item => item is not null).Cast<ItemDrop>().Select(Items.Serialize).ToList(),
         };
         GameProfile.Profile.ExtractedRuns.Insert(0, run);
         if (GameProfile.Profile.ExtractedRuns.Count > 10)
@@ -155,47 +151,6 @@ public static class MetaProgression
             GameProfile.IncrementQuest("path_clears");
             GameProfile.Profile.PathMastery[path] = GameProfile.Profile.PathMastery.GetValueOrDefault(path) + 1;
         }
-        GameProfile.SaveProfile();
-    }
-
-    public static bool TransferRunItemToStorage(string runId, int itemIndex)
-    {
-        if (GameProfile.Profile.Storage.Count >= StorageCapacity)
-            return false;
-        var run = GameProfile.Profile.ExtractedRuns.FirstOrDefault(item => item.Id == runId);
-        if (run is null || itemIndex < 0 || itemIndex >= run.Items.Count)
-            return false;
-        var item = run.Items[itemIndex];
-        run.Items.RemoveAt(itemIndex);
-        GameProfile.Profile.Storage.Add(item);
-        GameProfile.DiscoverItem(item.Name);
-        GameProfile.SaveProfile();
-        return true;
-    }
-
-    public static bool SelectStorageItem(int storageIndex)
-    {
-        if (storageIndex < 0 || storageIndex >= GameProfile.Profile.Storage.Count)
-            return false;
-        var stored = GameProfile.Profile.Storage[storageIndex];
-        var drop = Items.Deserialize(stored);
-        if (drop is null)
-            return false;
-        string[] compatible = drop.SlotType == "accessory" ? new[] { "accessory_1", "accessory_2" } : new[] { drop.SlotType };
-        string target = compatible.FirstOrDefault(slot => !GameProfile.Profile.StartingLoadout.ContainsKey(slot)) ?? compatible[0];
-        int promisedElsewhere = GameProfile.Profile.StartingLoadout.Count(pair => pair.Key != target && pair.Value == stored);
-        int ownedCopies = GameProfile.Profile.Storage.Count(item => item == stored);
-        if (promisedElsewhere >= ownedCopies)
-            return false;
-        GameProfile.Profile.StartingLoadout[target] = stored;
-        GameProfile.SaveProfile();
-        return true;
-    }
-
-    /// <summary>Un-assigns a slot from the next run's loadout -- the Soul's "NEXT RUN" preview strip's click-to-remove.</summary>
-    public static void ClearStartingLoadoutSlot(string slot)
-    {
-        GameProfile.Profile.StartingLoadout.Remove(slot);
         GameProfile.SaveProfile();
     }
 }

--- a/RotBoiRemastered/UI/InformationSheet.cs
+++ b/RotBoiRemastered/UI/InformationSheet.cs
@@ -92,6 +92,13 @@ public sealed class InformationSheet
     private sealed record EquipmentDragSource(string Key) : DragSource;
     private sealed record CrateDragSource(LootCrate Crate, int Index) : DragSource;
     private sealed record InventoryDragSource(int Index) : DragSource;
+    /// <summary>
+    /// The Soul's Vault (GameProfile.Profile.Storage) -- only reachable when the caller
+    /// passes vaultSlotRects into HandleDrag (the Soul does; normal gameplay doesn't, so
+    /// this stays entirely inert during a real run). Lets the Vault share the exact same
+    /// drag mechanic/feel as equipment/stash/crate instead of a separate implementation.
+    /// </summary>
+    private sealed record VaultDragSource(int Index) : DragSource;
 
     private float _uiScale;
     private int _screenWidth;
@@ -108,6 +115,8 @@ public sealed class InformationSheet
     private Dictionary<string, Rectangle> _equipmentSlotRects = new();
     private List<Rectangle> _lootPanelSlotRects = new();
     private List<Rectangle> _inventorySlotRects = new();
+    private IReadOnlyList<Rectangle> _vaultSlotRects = Array.Empty<Rectangle>();
+    private bool _allowWorldDrop = true;
     private bool _weaponStatsOpen;
 
     public int ArenaWidth => _posX;
@@ -795,11 +804,52 @@ public sealed class InformationSheet
     }
 
     /// <summary>
-    /// Press-capture / release-resolution half of the drag gesture. Call
-    /// once per frame, after <see cref="DrawSheet"/>.
+    /// A lighter sidebar for the Soul: just the equipment hub and stash, no
+    /// health/status/loot/objective/recent-picks -- none of that means
+    /// anything outside a run. Same visual language and the same
+    /// DrawInventory/DrawStash this class already uses in DrawSheet, so the
+    /// Soul's "your inventory" panel looks and behaves identically to the
+    /// in-run sidebar. Call once per frame, before HandleDrag, same contract
+    /// as DrawSheet.
     /// </summary>
-    public void HandleDrag(RunState state, Vector2 playerWorldPosition, Point mousePosition, bool mouseDown, bool mousePressed)
+    public void DrawCarriedLoadout(SpriteBatch spriteBatch, RunState state, Point mousePosition)
     {
+        _tooltip = null;
+        _tooltipItem = null;
+        Primitives2D.FillRect(spriteBatch, new Rectangle(_posX, 0, _totalLength, _totalHeight), UiTheme.Void);
+        Primitives2D.FillRect(spriteBatch, new Rectangle(_posX, 0, Px(6), _totalHeight), UiTheme.Ink);
+
+        int y = _padding;
+        y = DrawInventory(spriteBatch, state, mousePosition, y);
+        DrawStash(spriteBatch, state, mousePosition, y);
+
+        if (_draggingItem is not null)
+        {
+            int slotSize = Px(38);
+            var iconRect = new Rectangle(mousePosition.X - slotSize / 2, mousePosition.Y - slotSize / 2, slotSize, slotSize);
+            ItemCards.DrawItemCard(spriteBatch, iconRect, _draggingItem, hovered: true);
+        }
+        else
+        {
+            DrawTooltip(spriteBatch, mousePosition);
+        }
+    }
+
+    /// <summary>
+    /// Press-capture / release-resolution half of the drag gesture. Call once per frame,
+    /// after <see cref="DrawSheet"/> (or <see cref="DrawCarriedLoadout"/> in the Soul).
+    /// <paramref name="vaultSlotRects"/> is only ever non-null while in the Soul (see
+    /// SoulHub) -- a normal run leaves it null/empty, so the Vault-drag branches below
+    /// (and in ResolveDrop) never trigger during gameplay. <paramref name="allowWorldDrop"/>
+    /// is false only from the Soul too: the Soul never draws or lets you interact with
+    /// loot crates, so ejecting an invalid drop into one there would make the item
+    /// disappear for good -- cancel instead (see ResolveDrop's invalid-drop fallback).
+    /// </summary>
+    public void HandleDrag(RunState state, Vector2 playerWorldPosition, Point mousePosition, bool mouseDown, bool mousePressed,
+        IReadOnlyList<Rectangle>? vaultSlotRects = null, bool allowWorldDrop = true)
+    {
+        _vaultSlotRects = vaultSlotRects ?? Array.Empty<Rectangle>();
+        _allowWorldDrop = allowWorldDrop;
         if (_draggingItem is null)
         {
             if (!mousePressed)
@@ -831,6 +881,16 @@ public sealed class InformationSheet
                 {
                     _draggingItem = state.Inventory[index];
                     _draggingSource = new InventoryDragSource(index);
+                    DragInProgress = true;
+                    return;
+                }
+            }
+            for (int index = 0; index < _vaultSlotRects.Count; index++)
+            {
+                if (_vaultSlotRects[index].Contains(mousePosition) && index < GameProfile.Profile.Storage.Count)
+                {
+                    _draggingItem = Items.Deserialize(GameProfile.Profile.Storage[index]);
+                    _draggingSource = new VaultDragSource(index);
                     DragInProgress = true;
                     return;
                 }
@@ -886,6 +946,13 @@ public sealed class InformationSheet
                 (state.Inventory[equipFromStash.Index], state.Equipment[targetKey]) =
                     (state.Equipment[targetKey], state.Inventory[equipFromStash.Index]);
             }
+            else if (source is VaultDragSource equipFromVault)
+            {
+                var displaced = state.Equipment[targetKey];
+                state.Equipment[targetKey] = item;
+                PlaceInVault(equipFromVault.Index, displaced);
+                MetaProgression.SyncCarriedItems(state);
+            }
             return;
         }
 
@@ -921,8 +988,64 @@ public sealed class InformationSheet
                 GameProfile.DiscoverItem(item.Name);
                 ReturnDisplacedToCrate(state, crateSource, displaced);
             }
+            else if (source is VaultDragSource stashFromVault)
+            {
+                var displaced = state.Inventory[targetInventoryIndex];
+                state.Inventory[targetInventoryIndex] = item;
+                PlaceInVault(stashFromVault.Index, displaced);
+                MetaProgression.SyncCarriedItems(state);
+            }
             return;
         }
+
+        int targetVaultIndex = -1;
+        for (int index = 0; index < _vaultSlotRects.Count; index++)
+        {
+            if (_vaultSlotRects[index].Contains(mousePosition))
+            {
+                targetVaultIndex = index;
+                break;
+            }
+        }
+
+        if (targetVaultIndex >= 0)
+        {
+            var vault = GameProfile.Profile.Storage;
+            if (source is VaultDragSource selfVault)
+            {
+                if (selfVault.Index == targetVaultIndex)
+                    return; // released back over its own slot -- treat as a cancelled drag
+            }
+            if (targetVaultIndex >= vault.Count && vault.Count >= MetaProgression.StorageCapacity)
+                return; // vault full and this slot is past the current items -- cancel
+
+            ItemDrop? displaced = null;
+            if (targetVaultIndex < vault.Count)
+            {
+                displaced = Items.Deserialize(vault[targetVaultIndex]);
+                vault[targetVaultIndex] = Items.Serialize(item);
+            }
+            else
+            {
+                vault.Add(Items.Serialize(item));
+            }
+            if (source is EquipmentDragSource vaultFromEquipment) state.Equipment[vaultFromEquipment.Key] = displaced;
+            else if (source is InventoryDragSource vaultFromStash) state.Inventory[vaultFromStash.Index] = displaced;
+            else if (source is VaultDragSource vaultFromVault) PlaceInVault(vaultFromVault.Index, displaced);
+            else if (source is CrateDragSource vaultFromCrate)
+            {
+                // Not reachable today (no loot crates exist in the Soul, the only place
+                // vaultSlotRects is ever populated), but handled properly rather than left
+                // as a silent duplication bug if that ever changes.
+                GameProfile.DiscoverItem(item.Name);
+                ReturnDisplacedToCrate(state, vaultFromCrate, displaced);
+            }
+            MetaProgression.SyncCarriedItems(state);
+            return;
+        }
+
+        if (!_allowWorldDrop)
+            return; // the Soul has nowhere to eject an invalid drop to -- cancel, item stays put.
 
         if (source is EquipmentDragSource unequip)
         {
@@ -934,7 +1057,17 @@ public sealed class InformationSheet
             state.Inventory[unstash.Index] = null;
             DropIntoWorld(state, playerWorldPosition, item);
         }
-        // source is CrateDragSource and the drop target was invalid: no-op, item stays put.
+        // source is CrateDragSource or VaultDragSource and the drop target was invalid: no-op, item stays put.
+    }
+
+    /// <summary>Swaps the vault slot a drag came from back to `displaced`, or removes it if nothing displaced the dragged item.</summary>
+    private static void PlaceInVault(int index, ItemDrop? displaced)
+    {
+        var vault = GameProfile.Profile.Storage;
+        if (displaced is not null)
+            vault[index] = Items.Serialize(displaced);
+        else
+            vault.RemoveAt(index);
     }
 
     private static void ReturnDisplacedToCrate(RunState state, CrateDragSource crateSource, ItemDrop? displaced)

--- a/RotBoiRemastered/UI/SoulHub.cs
+++ b/RotBoiRemastered/UI/SoulHub.cs
@@ -28,13 +28,20 @@ public sealed class SoulHub
     public bool OverlayOpen => _overlay is not null;
     public void CloseOverlay() => _overlay = null;
 
+    /// <summary>
+    /// Hit rects for the Vault grid, refreshed each frame by DrawVault and fed into
+    /// GameSession.HandleCarriedLoadoutDrag -- the drag itself is owned by
+    /// InformationSheet (see its VaultDragSource), not this class, so the Vault shares
+    /// the exact same drag mechanic/feel as equipment/stash/crate dragging in a real run.
+    /// </summary>
+    private List<Rectangle> _vaultSlotRects = new();
+
     public void Enter(GameSession session)
     {
         session.State.EnemySpawningEnabled = false;
         session.State.AutoFire = false;
         session.State.EnemyHolster.Clear();
         session.State.EnemyProjectileHolster.Clear();
-        session.LoadPreviewEquipment();
         _dummyWorld = session.PlayerWorldCenter + new Vector2(Simulation.TileSize * 4, 0);
         _stationWorld.Clear();
         _stationWorld["storage"] = session.PlayerWorldCenter - new Vector2(Simulation.TileSize * 4, 0);
@@ -49,6 +56,7 @@ public sealed class SoulHub
         _sessionBest = 0;
         _lastRecordSave = 0;
         _overlay = null;
+        session.InformationSheet.CancelDrag();
     }
 
     public void Update(GameSession session, double elapsedSeconds)
@@ -86,7 +94,10 @@ public sealed class SoulHub
         session.UpdateDamageTexts();
     }
 
-    public void HandleInput(GameSession session, IReadOnlySet<Keys> keysPressed, Point mouse, bool mousePressed)
+    /// <summary>True while the carried-loadout sidebar (right side, same style/drag as gameplay) should be visible -- free-roam or the Vault open, not while browsing the other three stations.</summary>
+    private bool SidebarShown => _overlay is null || _overlay == "storage";
+
+    public void HandleInput(GameSession session, IReadOnlySet<Keys> keysPressed, Point mouse, bool mouseDown, bool mousePressed)
     {
         if (_overlay is not null)
         {
@@ -95,6 +106,7 @@ public sealed class SoulHub
             if (keysPressed.Contains(Keys.F) || walkedAway)
             {
                 _overlay = null;
+                session.InformationSheet.CancelDrag();
                 return;
             }
         }
@@ -104,19 +116,21 @@ public sealed class SoulHub
             if (nearby is not null)
                 _overlay = nearby;
         }
+        if (SidebarShown)
+        {
+            // _vaultSlotRects only gets refreshed while the Vault panel is actually drawn
+            // (DrawVault, gated on _overlay == "storage") -- pass an empty list otherwise,
+            // or a stale rect from a since-closed Vault could still register a pick-up in
+            // free-roam, over a spot nothing is being drawn anymore.
+            var vaultSlotRects = _overlay == "storage" ? _vaultSlotRects : (IReadOnlyList<Rectangle>)Array.Empty<Rectangle>();
+            session.HandleCarriedLoadoutDrag(mouse, mouseDown, mousePressed, vaultSlotRects);
+        }
         if (!mousePressed)
             return;
         foreach (var (key, rect) in _targets.ToArray())
         {
             if (!rect.Contains(mouse)) continue;
             if (key.StartsWith("skill:")) MetaProgression.PurchaseSkill(key[6..]);
-            else if (key.StartsWith("runitem:"))
-            {
-                var parts = key.Split(':');
-                MetaProgression.TransferRunItemToStorage(parts[1], int.Parse(parts[2]));
-            }
-            else if (key.StartsWith("stored:")) MetaProgression.SelectStorageItem(int.Parse(key[7..]));
-            else if (key.StartsWith("loadout:")) MetaProgression.ClearStartingLoadoutSlot(key[8..]);
             else if (key.StartsWith("cosmetic:"))
             {
                 var parts = key.Split(':');
@@ -159,14 +173,18 @@ public sealed class SoulHub
         UiTheme.DrawText(spriteBatch, "THE SOUL", 27, UiTheme.Text, new Vector2(22, 18));
         UiTheme.DrawText(spriteBatch, "SAFE GROUND  //  WALK TO A STATION  //  F INTERACT  //  ESC OPTIONS", 9, UiTheme.Muted, new Vector2(24, 54));
         DrawStations(spriteBatch, session);
-        if (_overlay is not null) DrawOverlay(spriteBatch, session.ScreenWidth, session.ScreenHeight, mouse);
+        if (_overlay is not null) DrawOverlay(spriteBatch, session, mouse);
+        // Drawn last so the dragged-item icon (part of this call, see
+        // InformationSheet.DrawCarriedLoadout) always renders on top, wherever the
+        // cursor currently is -- including over the Vault panel drawn just above.
+        if (SidebarShown) session.DrawCarriedLoadout(spriteBatch, mouse);
     }
 
     private void DrawStations(SpriteBatch spriteBatch, GameSession session)
     {
         var labels = new Dictionary<string, (string Label, Color Accent)>
         {
-            ["storage"] = ("EXTRACTION CHEST", UiTheme.Gold),
+            ["storage"] = ("VAULT", UiTheme.Gold),
             ["quests"] = ("QUEST ALTAR", UiTheme.Green),
             ["skills"] = ("SOUL GRID", UiTheme.Purple),
             ["wardrobe"] = ("WARDROBE", UiTheme.Blue),
@@ -188,14 +206,30 @@ public sealed class SoulHub
                 new Vector2(session.ScreenWidth / 2f, session.ScreenHeight - 42), "center");
     }
 
-    private void DrawOverlay(SpriteBatch spriteBatch, int screenWidth, int screenHeight, Point mouse)
+    private void DrawOverlay(SpriteBatch spriteBatch, GameSession session, Point mouse)
     {
         _tooltip = null;
+        int screenWidth = session.ScreenWidth, screenHeight = session.ScreenHeight;
+        if (_overlay == "storage")
+        {
+            // Bounded to the arena (left of the sidebar), a separate interface from the
+            // always-visible carried-loadout sidebar on the right -- see DrawWorld/
+            // SidebarShown. Doesn't darken/cover the sidebar, so it stays legible and
+            // draggable while the Vault is open.
+            int arenaWidth = session.InformationSheet.ArenaWidth;
+            Primitives2D.FillRect(spriteBatch, new Rectangle(0, 0, arenaWidth, screenHeight), UiTheme.Void * .94f);
+            var vaultPanel = new Rectangle((int)(arenaWidth * .07f), (int)(screenHeight * .12f),
+                (int)(arenaWidth * .55f), (int)(screenHeight * .72f));
+            UiTheme.DrawPanel(spriteBatch, vaultPanel, UiTheme.PanelRaised, UiTheme.Gold, shadow: 10);
+            DrawVault(spriteBatch, vaultPanel, mouse);
+            if (_tooltip is not null) DrawTooltip(spriteBatch, mouse, vaultPanel);
+            return;
+        }
+
         Primitives2D.FillRect(spriteBatch, new Rectangle(0, 0, screenWidth, screenHeight), UiTheme.Void * .94f);
         var panel = new Rectangle((int)(screenWidth * .055f), (int)(screenHeight * .07f),
             (int)(screenWidth * .89f), (int)(screenHeight * .80f));
         UiTheme.DrawPanel(spriteBatch, panel, UiTheme.PanelRaised, UiTheme.Green, shadow: 10);
-        if (_overlay == "storage") DrawStorage(spriteBatch, panel, mouse);
         if (_overlay == "quests") DrawQuests(spriteBatch, panel, mouse);
         if (_overlay == "skills") DrawSkills(spriteBatch, panel, mouse);
         if (_overlay == "wardrobe") DrawWardrobe(spriteBatch, panel, mouse);
@@ -204,80 +238,63 @@ public sealed class SoulHub
 
     private static string TimeLabel(double seconds) => $"{(int)seconds / 60:00}:{(int)seconds % 60:00}";
 
-    private static readonly (string Label, string Slot)[] NextRunSlots =
+    /// <summary>
+    /// Safe, permanent, MetaProgression.StorageCapacity-limited -- a separate interface
+    /// from the carried-loadout sidebar (session.DrawCarriedLoadout, the same style/hub
+    /// layout as a real run's sidebar, drawn on the right by DrawWorld). Drag items
+    /// between the two; the drag itself lives in InformationSheet (see its
+    /// VaultDragSource), fed this panel's slot rects via
+    /// GameSession.HandleCarriedLoadoutDrag -- there's no click-to-stage step anymore,
+    /// what's in your sidebar *is* what you're bringing into your next run, live.
+    /// </summary>
+    private void DrawVault(SpriteBatch spriteBatch, Rectangle panel, Point mouse)
     {
-        ("WEAPON", "weapon"), ("ARMOR", "armor"), ("RING", "ring"), ("ACC 1", "accessory_1"), ("ACC 2", "accessory_2"),
-    };
+        UiTheme.DrawText(spriteBatch, "VAULT", 24, UiTheme.Text, new Vector2(panel.X + 24, panel.Y + 18));
+        UiTheme.DrawText(spriteBatch, "SAFE, PERMANENT  //  DRAG ITEMS TO AND FROM YOUR INVENTORY", 9, UiTheme.Gold,
+            new Vector2(panel.X + 26, panel.Y + 53));
 
-    private void DrawStorage(SpriteBatch spriteBatch, Rectangle panel, Point mouse)
-    {
-        UiTheme.DrawText(spriteBatch, "EXTRACTION CHEST", 24, UiTheme.Text, new Vector2(panel.X + 24, panel.Y + 18));
-        UiTheme.DrawText(spriteBatch, $"PERMANENT STORAGE  {GameProfile.Profile.Storage.Count}/{MetaProgression.StorageCapacity}  //  CLICK A STORED ITEM TO STAGE IT BELOW  //  CLICK A STAGED SLOT TO REMOVE IT",
-            9, UiTheme.Gold, new Vector2(panel.X + 26, panel.Y + 53));
         int slotSize = 44, gap = 8;
+        const int vaultColumns = 5;
+        int vaultLeft = panel.X + 26, vaultTop = panel.Y + 80;
+        _vaultSlotRects = new List<Rectangle>();
         for (int index = 0; index < MetaProgression.StorageCapacity; index++)
         {
-            var rect = new Rectangle(panel.X + 26 + index * (slotSize + gap), panel.Y + 76, slotSize, slotSize);
+            int column = index % vaultColumns, row = index / vaultColumns;
+            var rect = new Rectangle(vaultLeft + column * (slotSize + gap), vaultTop + row * (slotSize + gap), slotSize, slotSize);
+            _vaultSlotRects.Add(rect);
             Primitives2D.FillRect(spriteBatch, rect, UiTheme.Ink);
-            bool promised = index < GameProfile.Profile.Storage.Count
-                && GameProfile.Profile.StartingLoadout.Values.Contains(GameProfile.Profile.Storage[index]);
-            Primitives2D.RectOutline(spriteBatch, rect, promised ? UiTheme.Cream : UiTheme.Border, promised ? 3 : 2);
+            Primitives2D.RectOutline(spriteBatch, rect, UiTheme.Border, 2);
             if (index >= GameProfile.Profile.Storage.Count) continue;
             var drop = Items.Deserialize(GameProfile.Profile.Storage[index]);
             if (drop is null) continue;
             ItemCards.DrawItemCard(spriteBatch, rect, drop, rect.Contains(mouse));
-            _targets[$"stored:{index}"] = rect;
-            if (rect.Contains(mouse))
-                _tooltip = promised
-                    ? $"{drop.Rarity} {drop.Name}  //  Staged for the next run."
-                    : $"{drop.Rarity} {drop.Name}  //  Click to prepare for the next run.";
+            if (rect.Contains(mouse)) _tooltip = $"{drop.Rarity} {drop.Name}  //  Drag to your inventory to carry it into a run.";
         }
+        int vaultRows = (MetaProgression.StorageCapacity + vaultColumns - 1) / vaultColumns;
+        UiTheme.DrawText(spriteBatch, $"{GameProfile.Profile.Storage.Count}/{MetaProgression.StorageCapacity}", 9, UiTheme.Muted,
+            new Vector2(vaultLeft, vaultTop + vaultRows * (slotSize + gap) + 4));
 
-        UiTheme.DrawText(spriteBatch, "NEXT RUN LOADOUT", 11, UiTheme.Cream, new Vector2(panel.X + 26, panel.Y + 132));
-        for (int index = 0; index < NextRunSlots.Length; index++)
-        {
-            var (label, slot) = NextRunSlots[index];
-            var rect = new Rectangle(panel.X + 26 + index * (slotSize + gap), panel.Y + 152, slotSize, slotSize);
-            Primitives2D.FillRect(spriteBatch, rect, UiTheme.Ink);
-            var stored = GameProfile.Profile.StartingLoadout.GetValueOrDefault(slot);
-            var staged = stored is null ? null : Items.Deserialize(stored);
-            Primitives2D.RectOutline(spriteBatch, rect, staged is not null ? UiTheme.Cream : UiTheme.Border, staged is not null ? 3 : 2);
-            UiTheme.DrawText(spriteBatch, label, 7, UiTheme.Muted, new Vector2(rect.Center.X, rect.Bottom + 3), "midtop");
-            if (staged is null) continue;
-            ItemCards.DrawItemCard(spriteBatch, rect, staged, rect.Contains(mouse));
-            _targets[$"loadout:{slot}"] = rect;
-            if (rect.Contains(mouse)) _tooltip = $"{staged.Rarity} {staged.Name}  //  Click to remove from the next run.";
-        }
-
-        int y = panel.Y + 204;
+        int y = vaultTop + vaultRows * (slotSize + gap) + 34;
+        UiTheme.DrawText(spriteBatch, "RUN HISTORY", 11, UiTheme.Muted, new Vector2(panel.X + 26, y));
+        y += 20;
         if (GameProfile.Profile.ExtractedRuns.Count == 0)
         {
-            UiTheme.DrawText(spriteBatch, "No extracted runs yet", 22, UiTheme.Muted, new Vector2(panel.Center.X, panel.Center.Y), "center");
-            UiTheme.DrawText(spriteBatch, "Reach a path ending or extract after the midpoint boss.", 10, UiTheme.Cream,
-                new Vector2(panel.Center.X, panel.Center.Y + 34), "center");
+            UiTheme.DrawText(spriteBatch, "No runs logged yet -- reach a path ending or extract after the midpoint boss.",
+                10, UiTheme.Cream, new Vector2(panel.X + 26, y));
             return;
         }
-        int columnGap = 14, runWidth = (panel.Width - 52 - columnGap) / 2;
-        int runHeight = Math.Max(64, (panel.Bottom - y - 18) / 5 - 6);
-        for (int index = 0; index < Math.Min(10, GameProfile.Profile.ExtractedRuns.Count); index++)
+        int runWidth = panel.Width - 52;
+        int shown = Math.Min(6, GameProfile.Profile.ExtractedRuns.Count);
+        int runHeight = Math.Max(26, (panel.Bottom - y - 18) / shown - 6);
+        for (int index = 0; index < shown; index++)
         {
             var run = GameProfile.Profile.ExtractedRuns[index];
-            int column = index / 5, rowIndex = index % 5;
-            var rect = new Rectangle(panel.X + 26 + column * (runWidth + columnGap), y + rowIndex * (runHeight + 6), runWidth, runHeight);
+            var rect = new Rectangle(panel.X + 26, y + index * (runHeight + 6), runWidth, runHeight);
             UiTheme.DrawPanel(spriteBatch, rect, UiTheme.Panel, UiTheme.Green);
             UiTheme.DrawText(spriteBatch, $"{index + 1:00}  {run.Path.ToUpperInvariant()}  //  {run.Outcome}", 9, UiTheme.Text,
-                new Vector2(rect.X + 9, rect.Y + 7));
+                new Vector2(rect.X + 9, rect.Center.Y), "midleft");
             UiTheme.DrawText(spriteBatch, $"LV {run.Level:00}  •  {run.Kills} KILLS  •  {TimeLabel(run.Seconds)}", 8, UiTheme.Muted,
-                new Vector2(rect.X + 9, rect.Y + 25));
-            for (int itemIndex = 0; itemIndex < run.Items.Count; itemIndex++)
-            {
-                var item = Items.Deserialize(run.Items[itemIndex]);
-                if (item is null) continue;
-                var itemRect = new Rectangle(rect.Right - 24 - itemIndex * 27, rect.Bottom - 28, 23, 23);
-                ItemCards.DrawItemCard(spriteBatch, itemRect, item, itemRect.Contains(mouse));
-                _targets[$"runitem:{run.Id}:{itemIndex}"] = itemRect;
-                if (itemRect.Contains(mouse)) _tooltip = $"SALVAGE {item.Rarity} {item.Name}  //  Click to move this item into permanent storage.";
-            }
+                new Vector2(rect.Right - 9, rect.Center.Y), "midright");
         }
     }
 


### PR DESCRIPTION
## Summary
- Equipment and the stash now persist across runs automatically instead of needing manual extraction/staging -- only lost on death. Removed the old BeginRun/PreviewLoadout/SelectStorageItem/TransferRunItemToStorage staging machinery in favor of `MetaProgression.SyncCarriedItems`/`ClearCarriedItems` and `GameSession.LoadCarriedItems`.
- The Soul's extraction station is now the Vault: a separate, arena-bounded panel on the left. The carried-loadout sidebar (equipment hub + stash) is always visible on the right while in the Soul, reusing `InformationSheet`'s real gameplay rendering and drag system directly (new `VaultDragSource`) instead of a bespoke implementation -- dragging between the Vault and your inventory now behaves identically to in-run equipment/stash/crate dragging.
- Fix: dropping an equipment/stash item on an invalid spot while in the Soul now cancels the drag instead of ejecting it into an invisible, unreachable loot crate (the Soul never draws or lets you interact with crates, so that path was silently deleting items).
- Extracted-run history stays as a read-only log (path/level/kills/time/outcome); item salvage no longer routes through it.

## Test plan
- [x] `dotnet build` -- clean
- [x] `dotnet test` -- 420/420 passing
- [ ] Manual check in-game: die and confirm loadout is lost; instead extract/complete/plain-restart and confirm it carries over; in the Soul, drag items both directions between the Vault and the sidebar (equipment + stash), confirm invalid drops cancel instead of vanishing, and confirm a drag's result survives a full quit-and-relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)