### PR TITLE
Turn the Soul into the run-launching hub

### DIFF
--- a/RotBoiRemastered/Core/RotBoiGame.cs
+++ b/RotBoiRemastered/Core/RotBoiGame.cs
@@ -278,16 +278,6 @@ public class RotBoiGame : Game
         var action = _titleScreen.HandleInput(InputState.KeysPressed, InputState.MousePosition, InputState.MousePressed);
         switch (action)
         {
-            case TitleAction.StartRun:
-            {
-                var battleground = GamePaths.ActivateSelected();
-                if (_session is null)
-                    _session = new GameSession(battleground, GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height);
-                else
-                    _session.ResetAll(battleground);
-                State = GameState.GameRun;
-                break;
-            }
             case TitleAction.EnterSoul:
             {
                 var battleground = GamePaths.ActivateSelected();
@@ -442,17 +432,33 @@ public class RotBoiGame : Game
     private void UpdateSoul(GameTime gameTime)
     {
         var session = _session!;
-        session.MovePlayer(Keybinds.Held("move_left"), Keybinds.Held("move_right"), Keybinds.Held("move_up"), Keybinds.Held("move_down"),
-            Keybinds.Pressed("dash") || InputState.ControllerDashPressed, InputState.ControllerMove);
-        _soulHub.HandleInput(session, InputState.KeysPressed, InputState.MousePosition, InputState.MouseDown, InputState.MousePressed);
-        if (_soulHub.OverlayOpen)
+        // Once a portal's pull-in animation is running, SoulHub.UpdatePortalTravel
+        // drives the player's world position directly -- ordinary WASD input would
+        // just fight that interpolation every frame.
+        if (!_soulHub.IsEnteringPortal)
+        {
+            session.MovePlayer(Keybinds.Held("move_left"), Keybinds.Held("move_right"), Keybinds.Held("move_up"), Keybinds.Held("move_down"),
+                Keybinds.Pressed("dash") || InputState.ControllerDashPressed, InputState.ControllerMove);
+        }
+        var enteredPathKey = _soulHub.HandleInput(session, InputState.KeysPressed, InputState.MousePosition, InputState.MouseDown, InputState.MousePressed);
+        if (enteredPathKey is not null)
+        {
+            GamePaths.Select(enteredPathKey);
+            session.ResetAll(GamePaths.ActivateSelected());
+            State = GameState.GameRun;
             return;
-        var aim = new Vector2(InputState.MousePosition.X, InputState.MousePosition.Y);
-        bool controllerFiring = InputState.ControllerAim.LengthSquared() > .0625f;
-        if (controllerFiring)
-            aim = session.Camera.Lock + InputState.ControllerAim * GraphicsDevice.Viewport.Width;
-        session.HandleBulletCreation(aim, InputState.MouseDown, session.InformationSheet.DragInProgress, controllerFiring: controllerFiring);
-        session.UpdateBullets();
+        }
+        if (!_soulHub.OverlayOpen && !_soulHub.IsEnteringPortal)
+        {
+            var aim = new Vector2(InputState.MousePosition.X, InputState.MousePosition.Y);
+            bool controllerFiring = InputState.ControllerAim.LengthSquared() > .0625f;
+            if (controllerFiring)
+                aim = session.Camera.Lock + InputState.ControllerAim * GraphicsDevice.Viewport.Width;
+            session.HandleBulletCreation(aim, InputState.MouseDown, session.InformationSheet.DragInProgress, controllerFiring: controllerFiring);
+            session.UpdateBullets();
+        }
+        // Always ticks, even mid-overlay/confirm/animation, so the portal
+        // pull/fade clock (both keyed off SoulHub's own _seconds) never stalls.
         _soulHub.Update(session, gameTime.ElapsedGameTime.TotalSeconds);
     }
 
@@ -575,9 +581,13 @@ public class RotBoiGame : Game
         session.DrawBackgroundFull(_spriteBatch, GraphicsDevice);
         _spriteBatch.Begin();
         session.DrawBullets(_spriteBatch);
-        session.DrawPlayer(_spriteBatch);
-        session.DrawDamageTexts(_spriteBatch);
+        // Stations/portals draw first, then the player on top of them (not
+        // behind), then the overlay/confirm/sidebar/fade layer on top of
+        // the player -- see SoulHub.DrawWorld/DrawForeground's doc comments.
         _soulHub.DrawWorld(_spriteBatch, session, InputState.MousePosition, InputState.MouseDown);
+        session.DrawPlayer(_spriteBatch, _soulHub.PlayerDrawScale);
+        session.DrawDamageTexts(_spriteBatch);
+        _soulHub.DrawForeground(_spriteBatch, session, InputState.MousePosition, InputState.MouseDown);
         _spriteBatch.End();
     }
 }

--- a/RotBoiRemastered/Entities/Player.cs
+++ b/RotBoiRemastered/Entities/Player.cs
@@ -150,20 +150,28 @@ public sealed class Player
         return false;
     }
 
-    /// <summary>Ported from character.py's drawPlayer(). Draws at the camera's screen lock, not a world-transformed position.</summary>
-    public void Draw(SpriteBatch spriteBatch, RunState state, Camera camera)
+    /// <summary>
+    /// Ported from character.py's drawPlayer(). Draws at the camera's screen
+    /// lock, not a world-transformed position. <paramref name="sizeScale"/>
+    /// is a purely cosmetic render-time multiplier (e.g. SoulHub's portal
+    /// pull-in shrink) -- it never touches RunState.PlayerSize, so collision/
+    /// combat sizing is untouched and there's nothing to reset when a real
+    /// run starts drawing at the default scale of 1.
+    /// </summary>
+    public void Draw(SpriteBatch spriteBatch, RunState state, Camera camera, float sizeScale = 1f)
     {
         bool flashOn = state.PlayerInvulnerabilityTimer > 0 && (int)(state.PlayerInvulnerabilityTimer / 4) % 2 == 0;
         Color color = flashOn ? new Color(235, 245, 255) : state.PlayerColor;
-        int half = (int)Math.Round(state.PlayerSize / 2f);
+        float drawSize = state.PlayerSize * sizeScale;
+        int half = (int)Math.Round(drawSize / 2f);
         var rect = new Rectangle((int)camera.Lock.X - half, (int)camera.Lock.Y - half,
-            (int)state.PlayerSize, (int)state.PlayerSize);
+            (int)drawSize, (int)drawSize);
 
         Primitives2D.FillRect(spriteBatch, new Rectangle(rect.X + 4, rect.Y + 4, rect.Width, rect.Height), UiTheme.Shadow);
         Primitives2D.FillRect(spriteBatch, rect, color);
         Primitives2D.RectOutline(spriteBatch, rect, state.Dashing ? UiTheme.Cream : state.PlayerEdgeColor, 3);
         var inset = rect;
-        inset.Inflate(-(int)(state.PlayerSize * .42f), -(int)(state.PlayerSize * .42f));
+        inset.Inflate(-(int)(drawSize * .42f), -(int)(drawSize * .42f));
         Primitives2D.FillRect(spriteBatch, inset, UiTheme.Lighten(color, 45));
     }
 }

--- a/RotBoiRemastered/Systems/GameSession.cs
+++ b/RotBoiRemastered/Systems/GameSession.cs
@@ -197,7 +197,7 @@ public sealed class GameSession
             GameProfile.IncrementQuest("distance_traveled", (long)Math.Round(traveled));
     }
 
-    public void DrawPlayer(SpriteBatch spriteBatch) => Player.Draw(spriteBatch, State, Camera);
+    public void DrawPlayer(SpriteBatch spriteBatch, float sizeScale = 1f) => Player.Draw(spriteBatch, State, Camera, sizeScale);
 
     /// <summary>Ported from character.py's handlingBulletCreation() for mouse and controller aiming.</summary>
     public void HandleBulletCreation(Vector2 mouseScreenPosition, bool mouseDown, bool dragInProgress, Random? rng = null, bool controllerFiring = false)

--- a/RotBoiRemastered/UI/SoulHub.cs
+++ b/RotBoiRemastered/UI/SoulHub.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Input;
 using RotBoiRemastered.Core;
 using RotBoiRemastered.Entities;
 using RotBoiRemastered.Systems;
+using RotBoiRemastered.World;
 
 namespace RotBoiRemastered.UI;
 
@@ -12,10 +13,27 @@ public sealed class SoulHub
 {
     private const float StationOpenRadiusTiles = 1.45f;
     private const float StationCloseRadiusTiles = 1.85f;
+    /// <summary>
+    /// Ring radius for the path portals -- well outside the four station
+    /// offsets (4 tiles) and the DPS dummy (also 4 tiles), and still clear of
+    /// every GamePaths generator's nearest building/block (the tightest
+    /// being Touch, whose closest cardinal-lane block sits ~18.8 tiles out),
+    /// so a 14-tile ring stays open ground in all five.
+    /// </summary>
+    private const float PathPortalRingRadiusTiles = 14f;
+    private const float PathPortalInteractRadiusTiles = 1.6f;
+    private const float PathPortalConfirmCloseRadiusTiles = 2.1f;
+    /// <summary>Time spent visibly pulling the player from where they confirmed into the portal's center.</summary>
+    private const double PortalPullSeconds = 0.9;
+    /// <summary>Time spent held at full black after the pull, so the scene swap underneath is never visible.</summary>
+    private const double PortalFadeSeconds = 0.45;
+    /// <summary>Smallest the player's cosmetic draw scale shrinks to mid-pull, selling a "falling in" look. Render-only (see Player.Draw) -- never touches RunState.PlayerSize, so there's nothing to reset when the next map loads at the default scale of 1.</summary>
+    private const float PortalMinPlayerScale = 0.3f;
     private sealed record DummyHit(double Time, double Damage);
     private readonly Queue<DummyHit> _dummyHits = new();
     private readonly Dictionary<string, Rectangle> _targets = new();
     private readonly Dictionary<string, Vector2> _stationWorld = new();
+    private readonly Dictionary<string, Vector2> _pathPortalWorld = new();
     private Vector2 _dummyWorld;
     private string? _overlay;
     private string? _tooltip;
@@ -25,8 +43,23 @@ public sealed class SoulHub
     private double _currentDps;
     private double _sessionBest;
     private double _lastRecordSave;
-    public bool OverlayOpen => _overlay is not null;
-    public void CloseOverlay() => _overlay = null;
+    /// <summary>Portal key awaiting an "ENTER X?" confirmation -- set on F near a portal, cleared by re-pressing F (confirm), walking away, or Escape.</summary>
+    private string? _confirmingPortalKey;
+    /// <summary>Portal key the player has committed to; drives the pull-in/fade animation until PortalPullSeconds + PortalFadeSeconds elapses.</summary>
+    private string? _enteringPortalKey;
+    private double _portalAnimationStart;
+    private Vector2 _portalTravelStart;
+    private float _playerDrawScale = 1f;
+    public bool OverlayOpen => _overlay is not null || _confirmingPortalKey is not null;
+    /// <summary>True once a portal has been confirmed -- movement and all other Soul interaction are suppressed for the remainder of the animation.</summary>
+    public bool IsEnteringPortal => _enteringPortalKey is not null;
+    /// <summary>Cosmetic player render scale (see Player.Draw) -- 1 outside the pull-in animation, easing down to PortalMinPlayerScale during it.</summary>
+    public float PlayerDrawScale => _playerDrawScale;
+    public void CloseOverlay()
+    {
+        _overlay = null;
+        _confirmingPortalKey = null;
+    }
 
     /// <summary>
     /// Hit rects for the Vault grid, refreshed each frame by DrawVault and fed into
@@ -48,6 +81,17 @@ public sealed class SoulHub
         _stationWorld["quests"] = session.PlayerWorldCenter - new Vector2(0, Simulation.TileSize * 4);
         _stationWorld["skills"] = session.PlayerWorldCenter + new Vector2(0, Simulation.TileSize * 4);
         _stationWorld["wardrobe"] = session.PlayerWorldCenter + new Vector2(-Simulation.TileSize * 4, Simulation.TileSize * 4);
+        _pathPortalWorld.Clear();
+        var paths = GamePaths.Paths;
+        for (int index = 0; index < paths.Count; index++)
+        {
+            // Start pointing straight up and go clockwise so the ring reads
+            // left-to-right the same order as GamePaths.Paths / the old
+            // title-screen selector.
+            float angle = -MathHelper.PiOver2 + MathHelper.TwoPi * index / paths.Count;
+            var offset = new Vector2(MathF.Cos(angle), MathF.Sin(angle)) * Simulation.TileSize * PathPortalRingRadiusTiles;
+            _pathPortalWorld[paths[index].Key] = session.PlayerWorldCenter + offset;
+        }
         _dummyHits.Clear();
         _seconds = 0;
         _measurementStart = 0;
@@ -56,12 +100,17 @@ public sealed class SoulHub
         _sessionBest = 0;
         _lastRecordSave = 0;
         _overlay = null;
+        _confirmingPortalKey = null;
+        _enteringPortalKey = null;
+        _playerDrawScale = 1f;
         session.InformationSheet.CancelDrag();
     }
 
     public void Update(GameSession session, double elapsedSeconds)
     {
         _seconds += Math.Min(.05, elapsedSeconds);
+        if (_enteringPortalKey is not null)
+            UpdatePortalTravel(session);
         var dummyRect = new Rectangle((int)(_dummyWorld.X - 34), (int)(_dummyWorld.Y - 44), 68, 88);
         foreach (var bullet in session.State.BulletHolster.Where(bullet => !bullet.RemFlag && dummyRect.Intersects(bullet.WorldRect())).ToArray())
         {
@@ -94,11 +143,67 @@ public sealed class SoulHub
         session.UpdateDamageTexts();
     }
 
+    /// <summary>
+    /// Eases the player's world position from where they confirmed toward the
+    /// portal's center over PortalPullSeconds -- since Player.Draw always
+    /// renders at the camera lock (a fixed screen point), moving WorldX/Y
+    /// scrolls the world around the player instead, which reads as the
+    /// portal sliding in to meet them. Player.SetPosition takes a top-left
+    /// corner, hence the half-size offset from the portal's stored center.
+    /// </summary>
+    private void UpdatePortalTravel(GameSession session)
+    {
+        double pullT = Math.Clamp((_seconds - _portalAnimationStart) / PortalPullSeconds, 0, 1);
+        float eased = (float)(pullT * pullT);
+        // Same eased factor drives the shrink as the position lerp, so the
+        // player visibly gets smaller at exactly the rate they close the
+        // distance -- reads as falling into the portal rather than just
+        // walking up to it.
+        _playerDrawScale = MathHelper.Lerp(1f, PortalMinPlayerScale, eased);
+        if (!_pathPortalWorld.TryGetValue(_enteringPortalKey!, out var target))
+            return;
+        var center = Vector2.Lerp(_portalTravelStart, target, eased);
+        float half = (float)session.State.PlayerSize / 2f;
+        session.Player.SetPosition(center.X - half, center.Y - half);
+    }
+
     /// <summary>True while the carried-loadout sidebar (right side, same style/drag as gameplay) should be visible -- free-roam or the Vault open, not while browsing the other three stations.</summary>
     private bool SidebarShown => _overlay is null || _overlay == "storage";
 
-    public void HandleInput(GameSession session, IReadOnlySet<Keys> keysPressed, Point mouse, bool mouseDown, bool mousePressed)
+    /// <summary>
+    /// Returns the GamePaths key of a portal whose entry animation just
+    /// finished (caller starts a run there), or null. A bare F near a portal
+    /// only opens the "ENTER X?" confirmation (see DrawPortalConfirm); a
+    /// second F commits, kicking off the pull-in/fade animation that this
+    /// method later reports as complete once IsEnteringPortal's clock runs out.
+    /// </summary>
+    public string? HandleInput(GameSession session, IReadOnlySet<Keys> keysPressed, Point mouse, bool mouseDown, bool mousePressed)
     {
+        if (_enteringPortalKey is not null)
+        {
+            if (_seconds - _portalAnimationStart < PortalPullSeconds + PortalFadeSeconds)
+                return null;
+            string finishedKey = _enteringPortalKey;
+            _enteringPortalKey = null;
+            return finishedKey;
+        }
+        if (_confirmingPortalKey is not null)
+        {
+            if (!_pathPortalWorld.TryGetValue(_confirmingPortalKey, out var portal)
+                || !WithinStationRadius(session.PlayerWorldCenter, portal, PathPortalConfirmCloseRadiusTiles))
+            {
+                _confirmingPortalKey = null;
+                return null;
+            }
+            if (keysPressed.Contains(Keys.F))
+            {
+                _enteringPortalKey = _confirmingPortalKey;
+                _confirmingPortalKey = null;
+                _portalAnimationStart = _seconds;
+                _portalTravelStart = session.PlayerWorldCenter;
+            }
+            return null;
+        }
         if (_overlay is not null)
         {
             bool walkedAway = !_stationWorld.TryGetValue(_overlay, out var station)
@@ -107,11 +212,17 @@ public sealed class SoulHub
             {
                 _overlay = null;
                 session.InformationSheet.CancelDrag();
-                return;
+                return null;
             }
         }
         else if (keysPressed.Contains(Keys.F))
         {
+            var nearbyPortal = NearbyPathPortal(session);
+            if (nearbyPortal is not null)
+            {
+                _confirmingPortalKey = nearbyPortal;
+                return null;
+            }
             var nearby = NearbyStation(session);
             if (nearby is not null)
                 _overlay = nearby;
@@ -126,7 +237,7 @@ public sealed class SoulHub
             session.HandleCarriedLoadoutDrag(mouse, mouseDown, mousePressed, vaultSlotRects);
         }
         if (!mousePressed)
-            return;
+            return null;
         foreach (var (key, rect) in _targets.ToArray())
         {
             if (!rect.Contains(mouse)) continue;
@@ -139,6 +250,7 @@ public sealed class SoulHub
             }
             break;
         }
+        return null;
     }
 
     private string? NearbyStation(GameSession session) => _stationWorld
@@ -147,9 +259,21 @@ public sealed class SoulHub
         .Select(station => station.Key)
         .FirstOrDefault();
 
+    private string? NearbyPathPortal(GameSession session) => _pathPortalWorld
+        .Where(portal => WithinStationRadius(session.PlayerWorldCenter, portal.Value, PathPortalInteractRadiusTiles))
+        .OrderBy(portal => Vector2.DistanceSquared(portal.Value, session.PlayerWorldCenter))
+        .Select(portal => portal.Key)
+        .FirstOrDefault();
+
     public static bool WithinStationRadius(Vector2 player, Vector2 station, float radiusTiles) =>
         Vector2.DistanceSquared(player, station) <= MathF.Pow(Simulation.TileSize * radiusTiles, 2);
 
+    /// <summary>
+    /// World-layer draw: the dummy, stations, and path portals -- everything
+    /// meant to sit *behind* the player. Call before GameSession.DrawPlayer;
+    /// pair with <see cref="DrawForeground"/> (called after) for the overlay/
+    /// confirm/sidebar/fade layers that must cover the player instead.
+    /// </summary>
     public void DrawWorld(SpriteBatch spriteBatch, GameSession session, Point mouse, bool mouseDown)
     {
         _targets.Clear();
@@ -171,13 +295,28 @@ public sealed class SoulHub
         UiTheme.DrawText(spriteBatch, $"SESSION {_sessionBest:0}  //  RECORD {GameProfile.Profile.BestDummyDps:0}", 8, UiTheme.Cream,
             new Vector2(readout.X + 14, readout.Y + 98));
         UiTheme.DrawText(spriteBatch, "THE SOUL", 27, UiTheme.Text, new Vector2(22, 18));
-        UiTheme.DrawText(spriteBatch, "SAFE GROUND  //  WALK TO A STATION  //  F INTERACT  //  ESC OPTIONS", 9, UiTheme.Muted, new Vector2(24, 54));
+        UiTheme.DrawText(spriteBatch, "SAFE GROUND  //  WALK TO A STATION OR PATH PORTAL  //  F INTERACT  //  ESC OPTIONS", 9, UiTheme.Muted, new Vector2(24, 54));
         DrawStations(spriteBatch, session);
+        DrawPathPortals(spriteBatch, session);
+    }
+
+    /// <summary>
+    /// UI-layer draw: overlay panels, the portal confirm modal, the carried-
+    /// loadout sidebar, and the portal fade -- everything meant to sit *on
+    /// top of* the player. Call after GameSession.DrawPlayer; see
+    /// <see cref="DrawWorld"/>.
+    /// </summary>
+    public void DrawForeground(SpriteBatch spriteBatch, GameSession session, Point mouse, bool mouseDown)
+    {
         if (_overlay is not null) DrawOverlay(spriteBatch, session, mouse);
+        if (_confirmingPortalKey is not null) DrawPortalConfirm(spriteBatch, session);
         // Drawn last so the dragged-item icon (part of this call, see
         // InformationSheet.DrawCarriedLoadout) always renders on top, wherever the
         // cursor currently is -- including over the Vault panel drawn just above.
         if (SidebarShown) session.DrawCarriedLoadout(spriteBatch, mouse);
+        // Absolute last: once committed, the fade must cover everything above
+        // (sidebar included) so the ResetAll scene swap underneath is never visible.
+        if (_enteringPortalKey is not null) DrawPortalFade(spriteBatch, session);
     }
 
     private void DrawStations(SpriteBatch spriteBatch, GameSession session)
@@ -204,6 +343,71 @@ public sealed class SoulHub
         if (nearby is not null)
             UiTheme.DrawText(spriteBatch, $"F  //  OPEN {labels[nearby].Label}", 13, labels[nearby].Accent,
                 new Vector2(session.ScreenWidth / 2f, session.ScreenHeight - 42), "center");
+    }
+
+    /// <summary>
+    /// One equally-spaced swirl portal per GamePaths entry, replacing the old
+    /// title-screen path selector -- walking up and pressing F (see
+    /// NearbyPathPortal/HandleInput) leaves the Soul and starts a run on that
+    /// path directly. Visual mirrors GameSession.DrawBossPortal's swirl (same
+    /// pulsing fill + rotating arcs) so an in-run boss portal and a Soul path
+    /// portal read as the same language, just tinted per path.
+    /// </summary>
+    private void DrawPathPortals(SpriteBatch spriteBatch, GameSession session)
+    {
+        float t = (float)_seconds;
+        string? nearbyPortal = NearbyPathPortal(session);
+        foreach (var path in GamePaths.Paths)
+        {
+            if (!_pathPortalWorld.TryGetValue(path.Key, out var world)) continue;
+            var screen = session.Camera.WorldToScreen(world, session.PlayerWorldCenter, Vector2.Zero);
+            float radius = Simulation.TileSize * 1.05f;
+            // Committing spins the destination portal up hard during the pull
+            // (see UpdatePortalTravel) so it visibly reels the player in,
+            // instead of sitting there identical to every other portal.
+            bool committing = path.Key == _enteringPortalKey;
+            float pullT = committing ? (float)Math.Clamp((_seconds - _portalAnimationStart) / PortalPullSeconds, 0, 1) : 0f;
+            float intensity = 1f + pullT * 2.2f;
+            float pulse = 1f + .06f * intensity * MathF.Sin(t * 2.2f * intensity + path.Key.GetHashCode());
+            Primitives2D.FillCircle(spriteBatch, screen, radius * .78f * pulse, UiTheme.Ink);
+            Primitives2D.CircleOutline(spriteBatch, screen, radius, path.Accent, 3);
+            for (int index = 0; index < 3; index++)
+            {
+                float speed = (1.4f + index * .55f) * intensity;
+                float phase = t * speed + index * (MathF.PI * 2f / 3f);
+                float ringRadius = radius * (.55f + index * .18f) * (1f - pullT * .35f);
+                var arcRect = new Rectangle((int)(screen.X - ringRadius), (int)(screen.Y - ringRadius), (int)(ringRadius * 2), (int)(ringRadius * 2));
+                Primitives2D.Arc(spriteBatch, arcRect, phase, phase + MathF.PI * .62f, path.Accent, 2);
+            }
+            UiTheme.DrawText(spriteBatch, path.Title, 10, path.Accent, new Vector2(screen.X, screen.Y + radius + 8), "midtop");
+            // Suppressed while confirming/entering that same portal -- the center
+            // confirmation panel (DrawPortalConfirm) already explains the prompt.
+            if (path.Key == nearbyPortal && path.Key != _confirmingPortalKey && _enteringPortalKey is null)
+                UiTheme.DrawText(spriteBatch, "F  //  ENTER", 9, UiTheme.Cream, new Vector2(screen.X, screen.Y + radius + 26), "midtop");
+        }
+    }
+
+    /// <summary>Centered "ENTER {PATH}?" modal shown while _confirmingPortalKey is set -- F commits, walking away or Escape cancels (Escape via OverlayOpen/CloseOverlay in Core/RotBoiGame.cs).</summary>
+    private void DrawPortalConfirm(SpriteBatch spriteBatch, GameSession session)
+    {
+        var path = GamePaths.PathsByKey[_confirmingPortalKey!];
+        int width = (int)(session.ScreenWidth * .34f), height = (int)(session.ScreenHeight * .2f);
+        var rect = new Rectangle(session.ScreenWidth / 2 - width / 2, (int)(session.ScreenHeight * .32f), width, height);
+        Primitives2D.FillRect(spriteBatch, new Rectangle(0, 0, session.ScreenWidth, session.ScreenHeight), UiTheme.Void * .55f);
+        UiTheme.DrawPanel(spriteBatch, rect, UiTheme.PanelRaised, path.Accent, shadow: 10);
+        UiTheme.DrawText(spriteBatch, $"ENTER {path.Title}?", 22, path.Accent, new Vector2(rect.Center.X, rect.Y + 26), "center");
+        UiTheme.DrawText(spriteBatch, path.Subtitle, 11, UiTheme.Cream, new Vector2(rect.Center.X, rect.Y + 62), "center");
+        UiTheme.DrawText(spriteBatch, "F  CONFIRM   //   WALK AWAY OR ESC  CANCEL", 10, UiTheme.Muted,
+            new Vector2(rect.Center.X, rect.Bottom - 24), "center");
+    }
+
+    /// <summary>Full-screen cover that ramps to solid black over the animation's second half, timed with UpdatePortalTravel so the arriving-at-portal moment and the fade-out land together.</summary>
+    private void DrawPortalFade(SpriteBatch spriteBatch, GameSession session)
+    {
+        double fadeT = Math.Clamp((_seconds - _portalAnimationStart - PortalPullSeconds) / PortalFadeSeconds, 0, 1);
+        if (fadeT <= 0)
+            return;
+        Primitives2D.FillRect(spriteBatch, new Rectangle(0, 0, session.ScreenWidth, session.ScreenHeight), UiTheme.Void * (float)fadeT);
     }
 
     private void DrawOverlay(SpriteBatch spriteBatch, GameSession session, Point mouse)

--- a/RotBoiRemastered/UI/TitleScreen.cs
+++ b/RotBoiRemastered/UI/TitleScreen.cs
@@ -3,22 +3,25 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using RotBoiRemastered.Core;
 using RotBoiRemastered.Systems;
-using RotBoiRemastered.World;
 
 namespace RotBoiRemastered.UI;
 
 /// <summary>What HandleInput determined should happen, matching MenuAction's return-a-result shape.</summary>
-public enum TitleAction { None, StartRun, EnterSoul, Settings, Quit }
+public enum TitleAction { None, EnterSoul, Settings, Quit }
 
 /// <summary>
-/// The title screen: path selector, play button, field manual, best-run tag.
-/// Ported from character.py's runTheTitleScreen() (one big function in
-/// Python too -- no separate helpers to extract). Follows Menus.cs's shape
-/// (Draw/HandleInput pair, no module globals) rather than mutating state
-/// directly -- the caller (Core/RotBoiGame.cs) is responsible for actually
-/// activating the selected path and constructing/resetting a GameSession on
-/// TitleAction.StartRun, matching Menus's established return-a-result
-/// contract.
+/// The title screen: entry point, field manual, best-run tag. Ported from
+/// character.py's runTheTitleScreen() (one big function in Python too -- no
+/// separate helpers to extract). Follows Menus.cs's shape (Draw/HandleInput
+/// pair, no module globals) rather than mutating state directly -- the
+/// caller (Core/RotBoiGame.cs) is responsible for actually activating a path
+/// and constructing/resetting a GameSession.
+///
+/// Path selection no longer happens here: The Soul is now the hub every run
+/// launches from, with one equally-spaced portal per GamePaths entry (see
+/// SoulHub.DrawPathPortals/NearbyPathPortal) standing in for the old
+/// title-screen selector grid + per-path "ENTER {TITLE}" button. This screen
+/// only gets you into the Soul.
 ///
 /// Dropped vs. Python: the best-run tag reads GameProfile.Profile.BestLevel/
 /// BestKills directly rather than `max(cS.highestLevel, profile["best_level"])`
@@ -29,8 +32,6 @@ public enum TitleAction { None, StartRun, EnterSoul, Settings, Quit }
 /// </summary>
 public sealed class TitleScreen
 {
-    private readonly Dictionary<string, Rectangle> _pathButtons = new();
-    private Rectangle _playButton;
     private Rectangle _soulButton;
     private Rectangle _settingsButton;
 
@@ -55,9 +56,9 @@ public sealed class TitleScreen
         // heights, gaps) only ever scaled with GuiScale via uiScale --
         // DrawButton's own shrink-to-fit loop has a floor (raw size 9) that
         // still renders far too wide once a high TextSize multiplies it, so
-        // without growing the boxes too, the five path buttons overlapped
-        // each other well before any single label's text could shrink
-        // enough to fit. uiScale now folds in the same growth-only factor
+        // without growing the boxes too, a long button label could overlap
+        // its own border well before the text could shrink enough to fit.
+        // uiScale now folds in the same growth-only factor
         // InformationSheet.TextGrowthFactor uses, so layout keeps pace with
         // whatever TextSize the text itself is already rendering at. The
         // extra headroom factor is capped well below MaxTextScale (2.0) --
@@ -84,46 +85,26 @@ public sealed class TitleScreen
         float subtitleY = Math.Max(screenHeight * .245f, titleRect.Bottom + gap);
         var subtitleRect = UiTheme.DrawText(spriteBatch, "R E M A S T E R E D", scale * .026, UiTheme.Cream, new Vector2(screenWidth / 2f, subtitleY), "midtop");
         float taglineY = Math.Max(screenHeight * .305f, subtitleRect.Bottom + gap);
-        var taglineRect = UiTheme.DrawText(spriteBatch, "CHOOSE WHAT THE ROT REMEMBERS.", scale * .019, UiTheme.Muted, new Vector2(screenWidth / 2f, taglineY), "midtop");
+        var taglineRect = UiTheme.DrawText(spriteBatch, "EVERY PATH WAITS IN THE SOUL.", scale * .019, UiTheme.Muted, new Vector2(screenWidth / 2f, taglineY), "midtop");
 
-        float selectorY = Math.Max(screenHeight * .365f, taglineRect.Bottom + gap * 2);
-        var paths = GamePaths.Paths;
-        float selectorWidth = (contentWidth - gap * (paths.Count - 1)) / paths.Count;
-        float selectorHeight = Math.Min(Math.Max(50 * uiScale, scale * .058f), scale * .085f);
-        _pathButtons.Clear();
-        for (int index = 0; index < paths.Count; index++)
-        {
-            var path = paths[index];
-            var rect = new Rectangle((int)(left + index * (selectorWidth + gap)), (int)selectorY,
-                (int)selectorWidth, (int)selectorHeight);
-            bool isSelected = path.Key == GamePaths.Selected().Key;
-            UiTheme.DrawButton(spriteBatch, rect, path.Title, mousePosition, mouseDown, true,
-                isSelected ? path.Accent : UiTheme.Border, null, (int)(scale * .014f));
-            _pathButtons[path.Key] = rect;
-        }
-
-        var selected = GamePaths.Selected();
-        float descriptionY = Math.Max(screenHeight * .455f, selectorY + selectorHeight + gap * 2);
-        var descriptionRect = UiTheme.DrawText(spriteBatch, $"{selected.Subtitle}  //  {selected.Description}", scale * .013, selected.Accent,
-            new Vector2(screenWidth / 2f, descriptionY), "midtop");
-        float playButtonY = Math.Max(screenHeight * .495f, descriptionRect.Bottom + gap * 2);
-        float playButtonHeight = Math.Min(Math.Max(54 * uiScale, scale * .064f), scale * .095f);
-        _playButton = new Rectangle((int)(left + contentWidth * .27f), (int)playButtonY,
-            (int)(contentWidth * .46f), (int)playButtonHeight);
-        UiTheme.DrawButton(spriteBatch, _playButton, $"ENTER {selected.Title}", mousePosition, mouseDown, true,
-            selected.Accent, "SPACE", (int)(scale * .019f));
-
-        float soulButtonY = Math.Max(screenHeight * .585f, playButtonY + playButtonHeight + gap * 2);
-        _soulButton = new Rectangle((int)(left + contentWidth * .18f), (int)soulButtonY,
-            (int)(contentWidth * .30f), (int)Math.Min(Math.Max(42 * uiScale, scale * .052f), scale * .078f));
+        // The old path-selector grid + per-path "ENTER {TITLE}" button lived
+        // here; path choice now happens by walking up to one of the Soul's
+        // equally-spaced path portals (see SoulHub.DrawPathPortals), so this
+        // screen's only job is getting the player into the Soul.
+        float soulButtonY = Math.Max(screenHeight * .5f, taglineRect.Bottom + gap * 4);
+        float soulButtonHeight = Math.Min(Math.Max(58 * uiScale, scale * .068f), scale * .098f);
+        _soulButton = new Rectangle((int)(left + contentWidth * .22f), (int)soulButtonY,
+            (int)(contentWidth * .56f), (int)soulButtonHeight);
         UiTheme.DrawButton(spriteBatch, _soulButton, "ENTER THE SOUL", mousePosition, mouseDown, true,
-            UiTheme.Purple, "F", (int)(scale * .014f));
-        _settingsButton = new Rectangle((int)(left + contentWidth * .52f), _soulButton.Y,
-            (int)(contentWidth * .30f), _soulButton.Height);
+            UiTheme.Purple, "SPACE / F", (int)(scale * .019f));
+
+        float settingsButtonY = Math.Max(screenHeight * .615f, soulButtonY + soulButtonHeight + gap * 2);
+        _settingsButton = new Rectangle((int)(left + contentWidth * .35f), (int)settingsButtonY,
+            (int)(contentWidth * .30f), (int)Math.Min(Math.Max(42 * uiScale, scale * .052f), scale * .078f));
         UiTheme.DrawButton(spriteBatch, _settingsButton, "SETTINGS", mousePosition, mouseDown, true,
             UiTheme.Blue, null, (int)(scale * .014f));
 
-        float controlsY = Math.Max(screenHeight * .665f, _soulButton.Bottom + gap * 2);
+        float controlsY = Math.Max(screenHeight * .665f, _settingsButton.Bottom + gap * 3);
         var controlsRect = new Rectangle((int)left, (int)controlsY, (int)contentWidth,
             (int)Math.Min(Math.Max(116 * uiScale, screenHeight * .15f), screenHeight * .21f));
         UiTheme.DrawPanel(spriteBatch, controlsRect, UiTheme.Panel, UiTheme.Border, shadow: 6);
@@ -146,41 +127,13 @@ public sealed class TitleScreen
         int bestLevel = GameProfile.Profile.BestLevel;
         string recordLabel = bestLevel <= 0 ? "NO RUNS LOGGED" : $"BEST RUN  //  LEVEL {bestLevel:D2}  //  {GameProfile.Profile.BestKills} KILLS";
         UiTheme.DrawTag(spriteBatch, recordLabel, new Vector2(left, screenHeight * .87f), bestLevel > 0 ? UiTheme.Gold : UiTheme.Border, scale * .012);
-        UiTheme.DrawText(spriteBatch, "A / D  SELECT PATH    ESC  QUIT", scale * .012, UiTheme.Muted,
+        UiTheme.DrawText(spriteBatch, "SPACE / F  ENTER THE SOUL    ESC  QUIT", scale * .012, UiTheme.Muted,
             new Vector2(left + contentWidth, screenHeight * .875f), "topright");
     }
 
-    /// <summary>
-    /// LEFT/A and RIGHT/D are hardcoded, not routed through Keybinds --
-    /// matching Python's own title screen (`pg.K_LEFT in vH.keyPressed or
-    /// pg.K_a in vH.keyPressed`), which never made these rebindable either.
-    /// </summary>
     public TitleAction HandleInput(IReadOnlySet<Keys> keysPressed, Point mousePosition, bool mousePressed)
     {
-        if (keysPressed.Contains(Keys.Left) || keysPressed.Contains(Keys.A))
-        {
-            GamePaths.Cycle(-1);
-        }
-        else if (keysPressed.Contains(Keys.Right) || keysPressed.Contains(Keys.D))
-        {
-            GamePaths.Cycle(1);
-        }
-        else if (mousePressed)
-        {
-            foreach (var (key, rect) in _pathButtons)
-            {
-                if (rect.Contains(mousePosition))
-                {
-                    GamePaths.Select(key);
-                    break;
-                }
-            }
-        }
-
-        bool playHovered = _playButton.Contains(mousePosition);
-        if (keysPressed.Contains(Keys.Space) || (playHovered && mousePressed))
-            return TitleAction.StartRun;
-        if (keysPressed.Contains(Keys.F) || (_soulButton.Contains(mousePosition) && mousePressed))
+        if (keysPressed.Contains(Keys.Space) || keysPressed.Contains(Keys.F) || (_soulButton.Contains(mousePosition) && mousePressed))
             return TitleAction.EnterSoul;
         if (_settingsButton.Contains(mousePosition) && mousePressed)
             return TitleAction.Settings;

--- a/RotBoiRemastered/UI/UiTheme.cs
+++ b/RotBoiRemastered/UI/UiTheme.cs
@@ -266,11 +266,20 @@ public static class UiTheme
         if (!string.IsNullOrEmpty(keyHint))
         {
             int inset = padding;
-            var hr = new Rectangle(visualRect.X + inset, visualRect.Y + inset,
-                visualRect.Height - inset * 2, visualRect.Height - inset * 2);
+            int boxHeight = visualRect.Height - inset * 2;
+            double hintTextSize = textSize * 0.72;
+            // A single-key hint ("R", "ESC") stays a square sized off the
+            // button's own height, same as before; a longer combo hint like
+            // "SPACE / F" instead grows the box to fit its measured width
+            // (plus its own padding) rather than overflowing a fixed square.
+            int hintPaddingX = Math.Max(8, (int)MathF.Round(10 * scale));
+            int textWidth = (int)MathF.Ceiling(Font(hintTextSize).MeasureString(keyHint).X);
+            int boxWidth = Math.Max(boxHeight, textWidth + hintPaddingX * 2);
+            var hr = new Rectangle(visualRect.X + inset, visualRect.Y + inset, boxWidth, boxHeight);
             hintRect = hr;
-            Primitives2D.FillRect(spriteBatch, hr, accent);
-            DrawText(spriteBatch, keyHint, textSize * 0.72, Ink,
+            int cornerRadius = Math.Max(3, (int)MathF.Round(6 * scale));
+            Primitives2D.FillRoundedRect(spriteBatch, hr, accent, cornerRadius);
+            DrawText(spriteBatch, keyHint, hintTextSize, Ink,
                 new Vector2(hr.Center.X, hr.Center.Y), "center");
         }
 


### PR DESCRIPTION
## Summary
- Replaces the title screen's path-selector grid with one equally-spaced portal per `GamePaths` entry, placed in a 14-tile ring inside the Soul (clear of every generator's nearest building). Walking up shows an "ENTER {PATH}?" confirmation; confirming eases the player into the portal (position lerp + cosmetic shrink) and fades to black before starting the run on that path.
- Title screen is now just the entry point into the Soul ("ENTER THE SOUL" + Settings); `TitleAction.StartRun` and the per-path selector/button are gone.
- Fixes the player rendering behind portals/stations by splitting `SoulHub.DrawWorld` into a backdrop layer (stations/portals) and a `DrawForeground` layer (overlays/confirm/sidebar/fade), with the player drawn in between.
- Fixes two title-screen layout bugs: the Field Manual panel overlapping the Settings button (wrong anchor), and `UiTheme.DrawButton`'s key-hint box overflowing for longer hints like "SPACE / F" (now measures and grows the box, with rounded corners).

## Test plan
- [x] `dotnet test RotBoiRemastered.Tests` — 425/425 passing
- [x] `dotnet build` on both the main project and test project — clean
- [x] Launched the game and confirmed via screenshot: rounded, correctly-sized key-hint badge; visible gap between Settings and Field Manual panel
- [ ] Manual playtest of the full portal confirm → pull-in → fade → run-start sequence in-game (not exercised by an automated driver in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)