### PR TITLE
Add optional sprite overlay and a fixed-stat unique-item system

### DIFF
--- a/RotBoiRemastered.Tests/Systems/ItemsTests.cs
+++ b/RotBoiRemastered.Tests/Systems/ItemsTests.cs
@@ -60,4 +60,53 @@ public class ItemsTests
         Assert.True(new ItemEffectView("Attack Speed", -3, 1).IsBeneficial);
         Assert.Equal("-10%", new ItemEffectView("Attack Speed", 0, 1.10).DisplayValue);
     }
+
+    [Fact]
+    public void RollUniqueDrop_NeverDropsForANonMatchingBossKey()
+    {
+        var rng = new Random(3);
+        for (int i = 0; i < 500; i++)
+            Assert.Null(Items.RollUniqueDrop("beaudis", rng));
+    }
+
+    [Fact]
+    public void RollUniqueDrop_CanDropForItsBossKey_AsFixedPowerUniqueRarity()
+    {
+        var rng = new Random(7);
+        var drops = Enumerable.Range(0, 500).Select(_ => Items.RollUniqueDrop("sting", rng)).Where(drop => drop is not null).ToList();
+
+        Assert.NotEmpty(drops);
+        Assert.All(drops, drop =>
+        {
+            Assert.Equal("Unique", drop!.Rarity);
+            Assert.Equal("Bow of Dread", drop.Name);
+        });
+    }
+
+    [Fact]
+    public void RarityPower_UniqueIsFixedAtFullPower_NotScaledLikeAnUnrecognizedRarity()
+    {
+        Assert.Equal(1.0, Items.RarityPower("Unique"));
+    }
+
+    [Fact]
+    public void Deserialize_RoundTripsAUniqueItem_DespiteItsRarityNotBeingInRarityOrder()
+    {
+        var original = new ItemDrop(Items.UniquesByName["Bow of Dread"], "Unique");
+
+        var restored = Items.Deserialize(Items.Serialize(original));
+
+        Assert.NotNull(restored);
+        Assert.Equal("Bow of Dread", restored!.Name);
+        Assert.Equal("Unique", restored.Rarity);
+        Assert.DoesNotContain("Unique", Upgrades.RarityOrder);
+    }
+
+    [Fact]
+    public void GenerateDrop_NeverProducesAUniqueItem()
+    {
+        var rng = new Random(9);
+        for (int i = 0; i < 500; i++)
+            Assert.DoesNotContain(Items.GenerateDrop(rng).Name, Items.UniquesByName.Keys);
+    }
 }

--- a/RotBoiRemastered.Tests/Systems/UniqueEffectsTests.cs
+++ b/RotBoiRemastered.Tests/Systems/UniqueEffectsTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.Xna.Framework;
+using RotBoiRemastered.Entities;
+using RotBoiRemastered.Systems;
+
+namespace RotBoiRemastered.Tests.Systems;
+
+public class UniqueEffectsTests
+{
+    private static ItemDrop BowOfDread() => new(Items.UniquesByName["Bow of Dread"], "Unique");
+
+    private static Bullet TestBullet(bool isCritical) =>
+        new(0, 0, speed: 1, direction: 0, bulletRange: 100, size: 10, Color.White, pierce: 1, damage: 10, isCritical);
+
+    [Fact]
+    public void OnPlayerHit_CanApplyDread_WhichSlowsAndAddsDamageTaken()
+    {
+        var boss = new Beaudis(0, 0, 100, new Random(4));
+        var weapon = BowOfDread();
+        var rng = new Random(1);
+        bool applied = false;
+        for (int i = 0; i < 200 && !applied; i++)
+        {
+            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: true), weapon, rng);
+            applied = boss.StatusEffects.ContainsKey("dread");
+        }
+
+        Assert.True(applied, "Dread should proc within 200 crit hits at a 32% per-hit chance.");
+        Assert.Equal(1.15, StatusEffects.DamageMultiplier(boss));
+
+        var control = StatusEffects.Update(boss, 0.1);
+        Assert.True(control.MovementMultiplier < 1);
+    }
+
+    [Fact]
+    public void OnPlayerHit_DoesNothing_ForAWeaponWithNoEffectId()
+    {
+        var boss = new Beaudis(0, 0, 100, new Random(4));
+        var ironDagger = new ItemDrop(Items.DefinitionsByName["Iron Dagger"], "Epic");
+        Assert.Null(ironDagger.Definition.EffectId);
+
+        var rng = new Random(1);
+        for (int i = 0; i < 200; i++)
+            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: true), ironDagger, rng);
+
+        Assert.False(boss.StatusEffects.ContainsKey("dread"));
+    }
+}

--- a/RotBoiRemastered/Content/Sprites/README.md
+++ b/RotBoiRemastered/Content/Sprites/README.md
@@ -1,0 +1,55 @@
+# Custom sprites
+
+Everything in this game renders procedurally by default (see `Core/Primitives2D.cs`).
+Dropping a PNG in the right spot here overrides that procedural drawing for
+just that one item/design/character -- nothing else changes, and nothing
+needs to be "finished" before any of it ships. See `Core/Sprites.cs` for the
+loader and `UI/ItemCards.cs` / `UI/ProjectileVisuals.cs` / `Entities/Player.cs`
+for the fallback checks.
+
+No build step needed: any `.png` placed under this folder is copied to the
+output directory automatically (see the wildcard `<None>` glob in
+`RotBoiRemastered.csproj`) and picked up at runtime. No `Content.mgcb`
+registration required.
+
+## Where files go
+
+The filename (minus `.png`) is always an id that already exists elsewhere in
+the code -- there's no separate id-to-file table to maintain.
+
+| Folder | Filename = | Source of the id |
+|---|---|---|
+| `Weapons/` | `ItemDefinition.VisualKind` | `Systems/Items.cs` (`dagger`, `sword`, `spear`, `bow`, `wand`) |
+| `Armor/` | `ItemDefinition.VisualKind` | `Systems/Items.cs` (`vest`, `chain`, `plate`) |
+| `Rings/` | `ItemDefinition.VisualKind` | `Systems/Items.cs` (`band`, `signet`) |
+| `Accessories/` | `ItemDefinition.VisualKind` | `Systems/Items.cs` (`charm`, `locket`, `badge`, `vial`, `bell`) |
+| `Bullets/` | `ProjectileDesign.Id` | `Systems/Cosmetics.cs` (`bulb`, `shard`, `lance`, `comet`, `fork`) |
+| `Player/` | fixed name `character.png` | one sprite, no selection yet -- see `Entities/Player.cs` |
+
+Example: giving the Iron Dagger real art means adding `Weapons/dagger.png` --
+every weapon whose `VisualKind` is `"dagger"` (Iron Dagger *and* Bloody
+Dagger) picks it up, since the icon is keyed by silhouette, not by the
+specific item name. Rarity/name differences still show through the item
+card's colored frame and text, same as today.
+
+## Art conventions
+
+- **Bullets** are drawn rotated to face travel direction, authored pointing
+  **right** (+X). `ProjectileVisuals.Draw` scales your sprite's larger
+  dimension to roughly `size * 1.6` -- keep the design roughly centered in
+  the canvas so rotation looks right.
+- **Bullets are not tinted** by the in-game core/edge color picker (Wardrobe)
+  once a sprite exists for that design -- they render at their authored
+  colors. If you want a design to stay recolorable, that needs a tinting
+  pass added later (e.g. author near-white/gray art and multiply by `core`).
+- **The player sprite** (`Player/character.png`) is drawn axis-aligned, never
+  rotated (the camera turns instead of the character). It's tinted cream
+  while dashing and near-white on invulnerability flash frames, same as the
+  procedural body, so those gameplay cues keep working once real art is in.
+- Sprites should be authored close to their target on-screen size
+  (`Simulation.TileSize` is 50px; the player draws at `TileSize * .75`) --
+  they're scaled to fit, not cropped.
+- Pixel art will render blurry until a `SamplerState.PointClamp` pass is
+  added to the relevant `spriteBatch.Begin()` calls (nothing currently
+  requests point filtering, since nothing but solid fills has existed to
+  filter). Flag this once real art is in if it looks soft.

--- a/RotBoiRemastered/Core/RotBoiGame.cs
+++ b/RotBoiRemastered/Core/RotBoiGame.cs
@@ -76,6 +76,7 @@ public class RotBoiGame : Game
         _spriteBatch = new SpriteBatch(GraphicsDevice);
         UiTheme.Initialize(GraphicsDevice);
         Primitives2D.Initialize(GraphicsDevice);
+        Sprites.Initialize(GraphicsDevice);
     }
 
     // ----- Update -----

--- a/RotBoiRemastered/Core/Sprites.cs
+++ b/RotBoiRemastered/Core/Sprites.cs
@@ -1,0 +1,66 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace RotBoiRemastered.Core;
+
+/// <summary>
+/// Optional sprite overlay for the game's otherwise fully-procedural
+/// (Primitives2D-drawn) rendering. Raw-loads PNGs straight off disk via
+/// Texture2D.FromStream, the same way UiTheme.Initialize loads the font --
+/// bypassing the MonoGame Content Pipeline (Content.mgcb) entirely so a new
+/// sprite just needs to be dropped under Content/Sprites/ (copied to the
+/// output directory by the wildcard &lt;None&gt; glob in the .csproj) with no
+/// pipeline manifest entry to maintain per file.
+///
+/// Every lookup is a soft miss: a key with no matching file returns null
+/// rather than throwing, so callers (ItemCards, ProjectileVisuals, Player)
+/// can fall back to their existing procedural drawing for anything not yet
+/// skinned. That's what lets sprites be added one at a time instead of
+/// needing full art coverage before any of it can ship.
+/// </summary>
+public static class Sprites
+{
+    private const string RootDirectory = "Content/Sprites";
+
+    private static GraphicsDevice? _graphicsDevice;
+    private static readonly Dictionary<string, Texture2D?> Cache = new();
+
+    public static void Initialize(GraphicsDevice graphicsDevice)
+    {
+        _graphicsDevice = graphicsDevice;
+        Cache.Clear();
+    }
+
+    /// <summary>
+    /// Looks up e.g. "Weapons/dagger" against Content/Sprites/Weapons/dagger.png
+    /// (relative to the running executable, matching where the build copies
+    /// everything else). Keys are derived directly from existing data --
+    /// ItemDefinition.VisualKind, ProjectileDesign.Id -- rather than a
+    /// hand-maintained id-to-file table, so there's nothing to keep in sync.
+    /// </summary>
+    public static Texture2D? TryGet(string key)
+    {
+        if (Cache.TryGetValue(key, out var cached))
+            return cached;
+        var texture = Load(key);
+        Cache[key] = texture;
+        return texture;
+    }
+
+    private static Texture2D? Load(string key)
+    {
+        if (_graphicsDevice is null)
+            return null;
+        string path = Path.Combine(AppContext.BaseDirectory, RootDirectory, key + ".png");
+        if (!File.Exists(path))
+            return null;
+        using var stream = File.OpenRead(path);
+        // MonoGame's DesktopGL Texture2D.FromStream does not premultiply
+        // alpha, unlike content-pipeline-built textures -- fine with the
+        // default BlendState.AlphaBlend for fully opaque or fully
+        // transparent pixels, but semi-transparent edges (soft-antialiased
+        // sprite edges) may show a faint dark fringe. Switch affected draw
+        // calls to BlendState.NonPremultiplied if that's visible once real
+        // art with soft edges is in.
+        return Texture2D.FromStream(_graphicsDevice, stream);
+    }
+}

--- a/RotBoiRemastered/Entities/Player.cs
+++ b/RotBoiRemastered/Entities/Player.cs
@@ -163,6 +163,23 @@ public sealed class Player
         bool flashOn = state.PlayerInvulnerabilityTimer > 0 && (int)(state.PlayerInvulnerabilityTimer / 4) % 2 == 0;
         Color color = flashOn ? new Color(235, 245, 255) : state.PlayerColor;
         float drawSize = state.PlayerSize * sizeScale;
+
+        // One fixed sprite slot, not a selectable list like ProjectileDesign
+        // -- there's no wardrobe UI for alternate skins yet. Never rotated
+        // (the camera turns instead of the character), but still tinted for
+        // the dash/invulnerability cues so those keep reading once real art
+        // replaces the procedural body.
+        var sprite = Sprites.TryGet("Player/character");
+        if (sprite is not null)
+        {
+            var origin = new Vector2(sprite.Width / 2f, sprite.Height / 2f);
+            float scale = drawSize / Math.Max(sprite.Width, sprite.Height);
+            Color tint = flashOn ? new Color(235, 245, 255) : state.Dashing ? UiTheme.Cream : Color.White;
+            spriteBatch.Draw(sprite, camera.Lock + new Vector2(4f, 4f), null, UiTheme.Shadow, 0f, origin, scale, SpriteEffects.None, 0f);
+            spriteBatch.Draw(sprite, camera.Lock, null, tint, 0f, origin, scale, SpriteEffects.None, 0f);
+            return;
+        }
+
         int half = (int)Math.Round(drawSize / 2f);
         var rect = new Rectangle((int)camera.Lock.X - half, (int)camera.Lock.Y - half,
             (int)drawSize, (int)drawSize);

--- a/RotBoiRemastered/RotBoiRemastered.csproj
+++ b/RotBoiRemastered/RotBoiRemastered.csproj
@@ -38,4 +38,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <!-- Same raw-copy treatment as the font above: any PNG dropped under
+         Content/Sprites/ is picked up automatically (no per-file entry, no
+         Content.mgcb registration) and read at runtime by Core/Sprites.cs. -->
+    <None Include="Content/Sprites/**/*.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/RotBoiRemastered/Systems/GameSession.cs
+++ b/RotBoiRemastered/Systems/GameSession.cs
@@ -738,7 +738,11 @@ public sealed class GameSession
                 double hitDamage = bullet.Damage * StatusEffects.DamageMultiplier(enemy, bullet);
                 var result = enemy.TakeDamage(hitDamage, collided.Part, DamageSource.Direct);
                 if (result.Applied && !result.Killed)
+                {
                     StatusEffects.RollPlayerHit(enemy, bullet, State.Equipment.Values, State.ProjectileCount, rng);
+                    if (State.Equipment.GetValueOrDefault("weapon") is { Definition.EffectId: not null } weapon)
+                        UniqueEffects.OnPlayerHit(enemy, bullet, weapon, rng);
+                }
                 if (result.Applied)
                 {
                     GameProfile.IncrementQuest("damage_dealt", Math.Max(0, (long)Math.Round(result.Amount)));
@@ -787,10 +791,19 @@ public sealed class GameSession
                 }
             }
 
-            int dropCount = Items.RollDropCount(rng);
-            if (dropCount > 0)
+            // Boss key computed up front (rather than inside the boss-only
+            // block below, as before) so RollUniqueDrop can add its result
+            // to this same crate -- a bonus unique is guaranteed a slot on
+            // the boss kill that earns it, independent of the regular
+            // RollDropCount roll that still runs (and could otherwise land
+            // on 0) for every enemy, boss or not.
+            string? defeatedBossKey = ReferenceEquals(enemy, State.ActiveBoss) ? (_activeBossKey ?? BossKeyFor(enemy)) : null;
+            var drops = Items.GenerateDrops(Items.RollDropCount(rng), rng);
+            if (defeatedBossKey is not null && Items.RollUniqueDrop(defeatedBossKey, rng) is { } uniqueDrop)
+                drops.Add(uniqueDrop);
+            if (drops.Count > 0)
             {
-                var crate = new LootCrate(enemy.WorldX, enemy.WorldY, Items.GenerateDrops(dropCount, rng));
+                var crate = new LootCrate(enemy.WorldX, enemy.WorldY, drops);
                 State.LootCrateList.Add(crate);
                 if (State.LootCrateList.Count > MaxLootCrates)
                 {
@@ -800,10 +813,9 @@ public sealed class GameSession
                 }
             }
 
-            if (ReferenceEquals(enemy, State.ActiveBoss))
+            if (defeatedBossKey is not null)
             {
                 GameProfile.IncrementQuest("bosses_defeated");
-                string? defeatedBossKey = _activeBossKey ?? BossKeyFor(enemy);
                 if (defeatedBossKey == GamePaths.BossKey(midpoint: true))
                 {
                     State.BeaudisDefeated = true;

--- a/RotBoiRemastered/Systems/Items.cs
+++ b/RotBoiRemastered/Systems/Items.cs
@@ -9,6 +9,17 @@ public sealed record ItemStatModifier(string Stat, double Additive = 0, double M
 /// Authored equipment archetype. VisualKind drives the deliberately generic
 /// silhouette (dagger, sword, spear, bow, wand, vest, and so on) while the
 /// modifiers keep all balance data out of rendering code.
+///
+/// EffectId/DropsFromBossKey/DropChance are only set on entries in
+/// <see cref="Items.Uniques"/> (null/default for every regular Definitions
+/// entry): EffectId names a bespoke on-hit behavior dispatched by
+/// UniqueEffects.OnPlayerHit (see its doc comment for why that's a separate
+/// hook rather than another StatusChances entry), DropsFromBossKey ties the
+/// drop to one specific boss kill rather than the regular loot table, and
+/// DropChance is that unique's own independent per-kill odds (see
+/// Items.RollUniqueDrop) -- multiple uniques can share a DropsFromBossKey,
+/// each with its own DropChance, which is what makes that boss's effective
+/// drop table.
 /// </summary>
 public sealed record ItemDefinition(
     string Name,
@@ -16,7 +27,10 @@ public sealed record ItemDefinition(
     string Description,
     string VisualKind,
     IReadOnlyList<ItemStatModifier> Modifiers,
-    IReadOnlyDictionary<string, double>? StatusChances = null);
+    IReadOnlyDictionary<string, double>? StatusChances = null,
+    string? EffectId = null,
+    string? DropsFromBossKey = null,
+    double DropChance = .12);
 
 public sealed record ItemDrop(ItemDefinition Definition, string Rarity)
 {
@@ -128,6 +142,53 @@ public static class Items
     public static readonly IReadOnlyDictionary<string, ItemDefinition> DefinitionsByName =
         Definitions.ToDictionary(definition => definition.Name);
 
+    /// <summary>
+    /// Fixed-stat named items (see ItemDefinition's doc comment) -- never
+    /// rolled by GenerateDrop/GenerateDrops, never rarity-scaled (RarityPower
+    /// treats "Unique" as a full, un-diminished 1.0), only obtainable via
+    /// RollUniqueDrop when the boss named in DropsFromBossKey is defeated.
+    /// </summary>
+    public static readonly IReadOnlyList<ItemDefinition> Uniques = new[]
+    {
+
+        //Template for new unique items:
+        /*
+        new ItemDefinition("Unique Name", "weapon/armor/ring/accessory", "Flavor text.",
+            "type_visual (vial/bow/dagger/bell/badge/etc.)", Mods(Mult("Bullet Damage", 0.00), Mult("Bullet Range", 0.00), Mult("Bullet Speed", 0.00)),
+            EffectId: "custom_effect_name", DropsFromBossKey: "boss_key", DropChance: .12),
+        */
+
+        new ItemDefinition("Bow of Dread", "weapon", "Every arrow carries a whisper of Dread, leaving struck enemies slowed and exposed.",
+            "bow", Mods(Mult("Bullet Damage", 1.35), Mult("Bullet Range", 1.85), Mult("Bullet Speed", 1.20)),
+            EffectId: "dread_on_hit", DropsFromBossKey: "sting", DropChance: .12),
+
+    };
+
+    public static readonly IReadOnlyDictionary<string, ItemDefinition> UniquesByName =
+        Uniques.ToDictionary(unique => unique.Name);
+
+    /// <summary>
+    /// Rolls every unique tied to this boss key independently against its
+    /// own DropChance -- that's the boss's drop table. See
+    /// GameSession.HandleDamagingEnemies' boss-defeat branch, which
+    /// guarantees a winning roll a loot crate slot regardless of the regular
+    /// RollDropCount roll. Candidates are shuffled first so, on the rare
+    /// kill where more than one entry wins its roll, it's not always the
+    /// first-declared one that gets returned -- RollUniqueDrop only ever
+    /// hands back one item per kill even if several uniques are eligible.
+    /// </summary>
+    public static ItemDrop? RollUniqueDrop(string bossKey, Random? rng = null)
+    {
+        rng ??= Random.Shared;
+        var candidates = Uniques.Where(unique => unique.DropsFromBossKey == bossKey).OrderBy(_ => rng.NextDouble());
+        foreach (var candidate in candidates)
+        {
+            if (rng.NextDouble() <= candidate.DropChance)
+                return new ItemDrop(candidate, "Unique");
+        }
+        return null;
+    }
+
     private static readonly int[] DropCounts = { 0, 1, 2, 3, 4 };
     private static readonly double[] DropCountWeights = { 55, 25, 12, 6, 2 };
 
@@ -163,7 +224,7 @@ public static class Items
         return Enumerable.Range(0, count).Select(_ => GenerateDrop(rng)).ToList();
     }
 
-    /// <summary>Rarity strengthens an item's identity without making drawbacks lethal.</summary>
+    /// <summary>Rarity strengthens an item's identity without making drawbacks lethal. "Unique" is fixed at a full, un-diminished 1.0 -- see Items.Uniques' doc comment.</summary>
     public static double RarityPower(string rarity) => rarity switch
     {
         "Common" => .65,
@@ -171,6 +232,7 @@ public static class Items
         "Epic" => 1.00,
         "Legendary" => 1.15,
         "Mythical" => 1.30,
+        "Unique" => 1.00,
         _ => .65,
     };
 
@@ -218,8 +280,15 @@ public static class Items
 
     public static StoredItemData Serialize(ItemDrop drop) => new(drop.Name, drop.Rarity);
 
-    public static ItemDrop? Deserialize(StoredItemData? data) => data is not null && DefinitionsByName.TryGetValue(data.Name, out var definition)
-        && Upgrades.RarityOrder.Contains(data.Rarity)
-        ? new ItemDrop(definition, data.Rarity)
-        : null;
+    /// <summary>Checked by name against Uniques first (their stored Rarity is always "Unique", which Upgrades.RarityOrder deliberately doesn't contain) before falling back to the regular, tiered-rarity-validated lookup.</summary>
+    public static ItemDrop? Deserialize(StoredItemData? data)
+    {
+        if (data is null)
+            return null;
+        if (UniquesByName.TryGetValue(data.Name, out var unique))
+            return new ItemDrop(unique, "Unique");
+        return DefinitionsByName.TryGetValue(data.Name, out var definition) && Upgrades.RarityOrder.Contains(data.Rarity)
+            ? new ItemDrop(definition, data.Rarity)
+            : null;
+    }
 }

--- a/RotBoiRemastered/Systems/StatusEffects.cs
+++ b/RotBoiRemastered/Systems/StatusEffects.cs
@@ -61,6 +61,8 @@ public static class StatusEffects
         double multiplier = 1;
         if (enemy.StatusEffects.ContainsKey("poison") && enemy.StatusEffects.ContainsKey("daze"))
             multiplier += .08;
+        if (enemy.StatusEffects.ContainsKey("dread"))
+            multiplier += .15;
         if (bullet?.IsCritical == true && enemy.StatusEffects.TryGetValue("bleed", out var bleed))
             multiplier += Math.Min(.20, bleed.Stacks * .025);
         return multiplier;
@@ -84,6 +86,7 @@ public static class StatusEffects
                 case "poison": dotPerSecond += Math.Max(2, enemy.MaxHp * effect.Potency) * effect.Stacks; break;
                 case "bleed": dotPerSecond += Math.Max(1, enemy.MaxHp * effect.Potency) * effect.Stacks; break;
                 case "slow": movement *= Math.Max(.45, 1 - effect.Potency); break;
+                case "dread": movement *= Math.Max(.40, 1 - effect.Potency); break;
                 case "daze": daze = Math.Max(daze, effect.Potency); break;
                 case "stun": stunned = true; break;
             }

--- a/RotBoiRemastered/Systems/UniqueEffects.cs
+++ b/RotBoiRemastered/Systems/UniqueEffects.cs
@@ -1,0 +1,35 @@
+using RotBoiRemastered.Entities;
+
+namespace RotBoiRemastered.Systems;
+
+/// <summary>
+/// Bespoke on-hit behavior for unique weapons (see Items.Uniques),
+/// dispatched by ItemDefinition.EffectId -- the counterpart to
+/// StatusEffects.RollPlayerHit, which only knows how to apply the same
+/// handful of generic, chance-driven ailments any item can roll into via
+/// Items.StatusChances. A unique's EffectId is a one-off hook instead: add a
+/// case here (and, if it leans on a new status kind like "dread" below, a
+/// case in StatusEffects.Update/DamageMultiplier too) for each new unique,
+/// rather than trying to force every future effect into the generic
+/// chance-dictionary shape that's shared across ordinary items.
+/// </summary>
+public static class UniqueEffects
+{
+    /// <summary>Called from GameSession.HandleDamagingEnemies right alongside StatusEffects.RollPlayerHit, once per non-killing hit, only when the equipped weapon has an EffectId.</summary>
+    public static void OnPlayerHit(Enemy enemy, Bullet bullet, ItemDrop weapon, Random? rng = null)
+    {
+        rng ??= Random.Shared;
+        switch (weapon.Definition.EffectId)
+        {
+            case "dread_on_hit":
+                // Roughly 1-in-5 hits (better than 1-in-3 on a crit) afflict
+                // Dread: a strong slow plus +15% damage taken for 3.5s -- see
+                // StatusEffects.Update's "dread" case for the slow and
+                // DamageMultiplier's for the damage-taken bonus.
+                double chance = bullet.IsCritical ? .32 : .18;
+                if (rng.NextDouble() <= chance)
+                    StatusEffects.Apply(enemy, "dread", duration: 3.5, potency: .55);
+                break;
+        }
+    }
+}

--- a/RotBoiRemastered/UI/InformationSheet.cs
+++ b/RotBoiRemastered/UI/InformationSheet.cs
@@ -732,7 +732,7 @@ public sealed class InformationSheet
         Primitives2D.RectOutline(spriteBatch, symbolRect, UiTheme.Ink, Px(2));
         var symbolInner = symbolRect;
         symbolInner.Inflate(-Px(7), -Px(7));
-        ItemCards.DrawItemSymbol(spriteBatch, item.SlotType, symbolInner, UiTheme.Ink, item.Definition.VisualKind);
+        ItemCards.DrawItemSymbol(spriteBatch, item.SlotType, symbolInner, UiTheme.Ink, item.Definition.VisualKind, item.Name);
         DrawSheetText(spriteBatch, item.Name.ToUpperInvariant(), Px(15), UiTheme.Text,
             new Vector2(symbolRect.Right + Px(11), rect.Y + Px(14)));
         DrawSheetText(spriteBatch, $"{item.Rarity.ToUpperInvariant()}  //  {item.SlotType.ToUpperInvariant()}", Px(9), rarity,

--- a/RotBoiRemastered/UI/ItemCards.cs
+++ b/RotBoiRemastered/UI/ItemCards.cs
@@ -8,12 +8,50 @@ namespace RotBoiRemastered.UI;
 /// <summary>Resolution-independent icons and mini cards for equippable loot items. Ported from itemCards.py.</summary>
 public static class ItemCards
 {
+    /// <summary>Sprite folder per slot type -- see Content/Sprites/README.md. Filename is the item's VisualKind, so e.g. slot "weapon" + kind "dagger" looks up Content/Sprites/Weapons/dagger.png.</summary>
+    private static readonly Dictionary<string, string> SpriteFolderBySlot = new()
+    {
+        ["weapon"] = "Weapons", ["armor"] = "Armor", ["ring"] = "Rings", ["accessory"] = "Accessories",
+    };
+
     private static void DrawLine(SpriteBatch spriteBatch, Color color, Vector2 start, Vector2 end, float width)
         => Primitives2D.Line(spriteBatch, start, end, color, Math.Max(1, (int)width));
 
-    public static void DrawItemSymbol(SpriteBatch spriteBatch, string slotType, Rectangle rect, Color? color = null,
-        string? visualKind = null)
+    /// <summary>
+    /// Draws a sprite for (slotType, itemName, visualKind) if one has been
+    /// added under Content/Sprites, scaled to fill rect. Tries the specific
+    /// item name first (e.g. Weapons/bow_of_dread.png) so a unique -- or any
+    /// item that outgrows sharing its VisualKind's generic art -- can get a
+    /// sprite distinct from every other item of that same silhouette,
+    /// falling back to the shared VisualKind sprite otherwise. Unlike the
+    /// procedural symbol below, neither tier applies `color` -- authored art
+    /// carries its own palette rather than being flattened to a single ink tint.
+    /// </summary>
+    private static bool TryDrawItemSprite(SpriteBatch spriteBatch, string slotType, string? itemName, string visualKind, Rectangle rect)
     {
+        if (!SpriteFolderBySlot.TryGetValue(slotType.ToLowerInvariant(), out var folder))
+            return false;
+        var sprite = (itemName is not null ? Sprites.TryGet($"{folder}/{Slug(itemName)}") : null)
+            ?? Sprites.TryGet($"{folder}/{visualKind}");
+        if (sprite is null)
+            return false;
+        spriteBatch.Draw(sprite, rect, Color.White);
+        return true;
+    }
+
+    /// <summary>"Bow of Dread" -> "bow_of_dread", matching how a sprite file for a specific item should be named.</summary>
+    private static string Slug(string name)
+    {
+        var cleaned = new string(name.ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : ' ').ToArray());
+        return string.Join('_', cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    public static void DrawItemSymbol(SpriteBatch spriteBatch, string slotType, Rectangle rect, Color? color = null,
+        string? visualKind = null, string? itemName = null)
+    {
+        if (visualKind is not null && TryDrawItemSprite(spriteBatch, slotType, itemName, visualKind, rect))
+            return;
+
         Color drawColor = color ?? UiTheme.Text;
         float cx = rect.Center.X, cy = rect.Center.Y;
         float unit = Math.Max(1f, Math.Min(rect.Width, rect.Height) / 20f);
@@ -161,7 +199,7 @@ public static class ItemCards
         Primitives2D.RoundedRectOutline(spriteBatch, rect, UiTheme.Ink, Math.Max(2, rect.Width / 14), cornerRadius);
         var inner = rect;
         inner.Inflate((int)(-rect.Width * .15f), (int)(-rect.Height * .18f));
-        DrawItemSymbol(spriteBatch, item.SlotType, inner, UiTheme.Ink, item.Definition.VisualKind);
+        DrawItemSymbol(spriteBatch, item.SlotType, inner, UiTheme.Ink, item.Definition.VisualKind, item.Name);
         return rect;
     }
 }

--- a/RotBoiRemastered/UI/ProjectileVisuals.cs
+++ b/RotBoiRemastered/UI/ProjectileVisuals.cs
@@ -21,7 +21,19 @@ public static class ProjectileVisuals
         Vector2 P(float x, float y) => center + forward * (x * size) + side * (y * size);
         Vector2[] Shape(params (float X, float Y)[] points) => points.Select(point => P(point.X, point.Y)).ToArray();
 
-        if (design == "shard")
+        var sprite = Sprites.TryGet($"Bullets/{design}");
+        if (sprite is not null)
+        {
+            // Authored pointing +X (forward, pre-rotation) -- see
+            // Content/Sprites/README.md. Not tinted by core/edge: authored
+            // art keeps its own palette rather than being flattened to the
+            // Wardrobe's color picker, unlike the procedural shapes below.
+            float rotation = MathF.Atan2(forward.Y, forward.X);
+            var origin = new Vector2(sprite.Width / 2f, sprite.Height / 2f);
+            float scale = size * 1.6f / Math.Max(sprite.Width, sprite.Height);
+            spriteBatch.Draw(sprite, center, null, Color.White, rotation, origin, scale, SpriteEffects.None, 0f);
+        }
+        else if (design == "shard")
         {
             FillLayer(spriteBatch, Shape((-.62f, -.27f), (.12f, -.40f), (.70f, 0), (.12f, .40f), (-.62f, .27f)), edge);
             FillLayer(spriteBatch, Shape((-.43f, -.14f), (.10f, -.24f), (.48f, 0), (.10f, .24f), (-.43f, .14f)), core);

--- a/RotBoiRemastered/UI/UiTheme.cs
+++ b/RotBoiRemastered/UI/UiTheme.cs
@@ -45,6 +45,7 @@ public static class UiTheme
         ["Epic"] = Purple,
         ["Legendary"] = Gold,
         ["Mythical"] = new Color(245, 241, 220),
+        ["Unique"] = new Color(224, 96, 43),
     };
 
     public const int ReferenceWidth = 1920;


### PR DESCRIPTION
## Summary
- **Sprites** (`Core/Sprites.cs`): raw-loads PNGs from `Content/Sprites/`, bypassing the Content Pipeline the same way the font already does. Keys are derived from existing ids (`ItemDefinition.VisualKind`, `ProjectileDesign.Id`, a fixed player slot) rather than a hand-maintained table, and every lookup soft-misses to `null` so `ItemCards`/`ProjectileVisuals`/`Player` can fall back to their existing procedural drawing for anything not yet skinned — art can be added one file at a time.
- **Unique items** (`Systems/Items.cs`, new `Systems/UniqueEffects.cs`): `Items.Uniques` holds fixed-stat named items (no rarity scaling — `RarityPower("Unique") == 1.0`) that never enter the regular loot table, obtainable only via `Items.RollUniqueDrop` when the boss named in `DropsFromBossKey` dies. Each unique has its own independent `DropChance`, so multiple uniques sharing a boss key form that boss's own drop table. Bespoke on-hit behavior (Bow of Dread's Dread status: slow + increased damage taken) dispatches through `UniqueEffects.OnPlayerHit` by `EffectId`, alongside the existing generic `StatusEffects` chance-driven pipeline.
- `GameSession.HandleDamagingEnemies` now computes the defeated boss's key up front so a won unique roll always gets a slot in that kill's loot crate, independent of the regular `RollDropCount` roll.
- Added a `"Unique"` rarity color to `UiTheme` and a name-then-VisualKind sprite lookup tier in `ItemCards` so a unique (or any item) can get art distinct from everything sharing its silhouette.

## Test plan
- [x] `dotnet build` (main project + test project) — clean
- [x] `dotnet test` — 432/432 passing, including new `ItemsTests`/`UniqueEffectsTests` coverage for drop gating, fixed rarity power, deserialize round-trip, and the Dread status's slow/damage-taken effects
- [x] Verified live in-game via screenshots: a test sprite correctly overriding an item's procedural icon, and a seeded "Bow of Dread" in `CarriedEquipment` rendering with the new Unique rarity color

🤖 Generated with [Claude Code](https://claude.com/claude-code)