### PR TITLE
Let a unique weapon stack multiple independent on-hit effects

### DIFF
--- a/RotBoiRemastered.Tests/Systems/UniqueEffectsTests.cs
+++ b/RotBoiRemastered.Tests/Systems/UniqueEffectsTests.cs
@@ -16,11 +16,12 @@ public class UniqueEffectsTests
     {
         var boss = new Beaudis(0, 0, 100, new Random(4));
         var weapon = BowOfDread();
+        var state = new RunState();
         var rng = new Random(1);
         bool applied = false;
         for (int i = 0; i < 200 && !applied; i++)
         {
-            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: true), weapon, rng);
+            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: true), weapon, state, rng);
             applied = boss.StatusEffects.ContainsKey("dread");
         }
 
@@ -32,15 +33,34 @@ public class UniqueEffectsTests
     }
 
     [Fact]
-    public void OnPlayerHit_DoesNothing_ForAWeaponWithNoEffectId()
+    public void OnPlayerHit_RunsEveryListedEffectIndependently_FromOneWeapon()
+    {
+        // Bow of Dread lists two EffectIds -- proves both fire off the same
+        // weapon, from the same hits, without either one's roll/state
+        // touching the other's.
+        var boss = new Beaudis(0, 0, 100, new Random(4));
+        var weapon = BowOfDread();
+        var state = new RunState { HealthPoints = 500 };
+        var rng = new Random(2);
+
+        for (int i = 0; i < 200; i++)
+            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: true), weapon, state, rng);
+
+        Assert.True(boss.StatusEffects.ContainsKey("dread"), "dread_on_hit should have procced at least once in 200 hits.");
+        Assert.True(state.HealthPoints > 500, "dread_lifesteal should have healed the player at least once in 200 hits.");
+    }
+
+    [Fact]
+    public void OnPlayerHit_DoesNothing_ForAWeaponWithNoEffectIds()
     {
         var boss = new Beaudis(0, 0, 100, new Random(4));
         var ironDagger = new ItemDrop(Items.DefinitionsByName["Iron Dagger"], "Epic");
-        Assert.Null(ironDagger.Definition.EffectId);
+        Assert.Null(ironDagger.Definition.EffectIds);
 
+        var state = new RunState();
         var rng = new Random(1);
         for (int i = 0; i < 200; i++)
-            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: true), ironDagger, rng);
+            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: true), ironDagger, state, rng);
 
         Assert.False(boss.StatusEffects.ContainsKey("dread"));
     }

--- a/RotBoiRemastered/Systems/GameSession.cs
+++ b/RotBoiRemastered/Systems/GameSession.cs
@@ -740,8 +740,8 @@ public sealed class GameSession
                 if (result.Applied && !result.Killed)
                 {
                     StatusEffects.RollPlayerHit(enemy, bullet, State.Equipment.Values, State.ProjectileCount, rng);
-                    if (State.Equipment.GetValueOrDefault("weapon") is { Definition.EffectId: not null } weapon)
-                        UniqueEffects.OnPlayerHit(enemy, bullet, weapon, rng);
+                    if (State.Equipment.GetValueOrDefault("weapon") is { Definition.EffectIds.Count: > 0 } weapon)
+                        UniqueEffects.OnPlayerHit(enemy, bullet, weapon, State, rng);
                 }
                 if (result.Applied)
                 {

--- a/RotBoiRemastered/Systems/Items.cs
+++ b/RotBoiRemastered/Systems/Items.cs
@@ -10,16 +10,18 @@ public sealed record ItemStatModifier(string Stat, double Additive = 0, double M
 /// silhouette (dagger, sword, spear, bow, wand, vest, and so on) while the
 /// modifiers keep all balance data out of rendering code.
 ///
-/// EffectId/DropsFromBossKey/DropChance are only set on entries in
+/// EffectIds/DropsFromBossKey/DropChance are only set on entries in
 /// <see cref="Items.Uniques"/> (null/default for every regular Definitions
-/// entry): EffectId names a bespoke on-hit behavior dispatched by
-/// UniqueEffects.OnPlayerHit (see its doc comment for why that's a separate
-/// hook rather than another StatusChances entry), DropsFromBossKey ties the
-/// drop to one specific boss kill rather than the regular loot table, and
-/// DropChance is that unique's own independent per-kill odds (see
-/// Items.RollUniqueDrop) -- multiple uniques can share a DropsFromBossKey,
-/// each with its own DropChance, which is what makes that boss's effective
-/// drop table.
+/// entry): EffectIds names zero or more bespoke on-hit behaviors dispatched
+/// by UniqueEffects.OnPlayerHit (see its doc comment for why that's a
+/// separate hook rather than another StatusChances entry) -- a weapon can
+/// list more than one to stack independent effects (e.g. a crowd-control
+/// proc and a sustain proc) on the same item, each added as its own case
+/// with no knowledge of the others. DropsFromBossKey ties the drop to one
+/// specific boss kill rather than the regular loot table, and DropChance is
+/// that unique's own independent per-kill odds (see Items.RollUniqueDrop)
+/// -- multiple uniques can share a DropsFromBossKey, each with its own
+/// DropChance, which is what makes that boss's effective drop table.
 /// </summary>
 public sealed record ItemDefinition(
     string Name,
@@ -28,7 +30,7 @@ public sealed record ItemDefinition(
     string VisualKind,
     IReadOnlyList<ItemStatModifier> Modifiers,
     IReadOnlyDictionary<string, double>? StatusChances = null,
-    string? EffectId = null,
+    IReadOnlyList<string>? EffectIds = null,
     string? DropsFromBossKey = null,
     double DropChance = .12);
 
@@ -151,16 +153,20 @@ public static class Items
     public static readonly IReadOnlyList<ItemDefinition> Uniques = new[]
     {
 
-        //Template for new unique items:
+        //Template for new unique items -- list one or more EffectIds to stack independent effects on the same item (see UniqueEffects.OnPlayerHit):
         /*
         new ItemDefinition("Unique Name", "weapon/armor/ring/accessory", "Flavor text.",
             "type_visual (vial/bow/dagger/bell/badge/etc.)", Mods(Mult("Bullet Damage", 0.00), Mult("Bullet Range", 0.00), Mult("Bullet Speed", 0.00)),
-            EffectId: "custom_effect_name", DropsFromBossKey: "boss_key", DropChance: .12),
+            EffectIds: new[] { "custom_effect_name", "second_effect_name" }, DropsFromBossKey: "boss_key", DropChance: .12),
         */
 
-        new ItemDefinition("Bow of Dread", "weapon", "Every arrow carries a whisper of Dread, leaving struck enemies slowed and exposed.",
+        new ItemDefinition("Bow of Dread", "weapon", "Every arrow carries a whisper of Dread, leaving struck enemies slowed and exposed -- and the bow itself feeds on the fear it causes.",
             "bow", Mods(Mult("Bullet Damage", 1.35), Mult("Bullet Range", 1.85), Mult("Bullet Speed", 1.20)),
-            EffectId: "dread_on_hit", DropsFromBossKey: "sting", DropChance: .12),
+            EffectIds: new[] { "dread_on_hit", "dread_lifesteal" }, DropsFromBossKey: "sting", DropChance: .12),
+
+        new ItemDefinition("Grimsbane", "weapon", "Darkness clings to the rigid bones, and the shadows it strikes shiver in fear.",
+            "bow", Mods(Mult("Bullet Damage", 1.20), Mult("Bullet Range", .35), Mult("Attack Speed", .85)),
+            EffectIds: new[] { "grimsbane_effect" }, DropsFromBossKey: "dissonance", DropChance: .12),
 
     };
 

--- a/RotBoiRemastered/Systems/UniqueEffects.cs
+++ b/RotBoiRemastered/Systems/UniqueEffects.cs
@@ -4,32 +4,53 @@ namespace RotBoiRemastered.Systems;
 
 /// <summary>
 /// Bespoke on-hit behavior for unique weapons (see Items.Uniques),
-/// dispatched by ItemDefinition.EffectId -- the counterpart to
+/// dispatched by ItemDefinition.EffectIds -- the counterpart to
 /// StatusEffects.RollPlayerHit, which only knows how to apply the same
 /// handful of generic, chance-driven ailments any item can roll into via
-/// Items.StatusChances. A unique's EffectId is a one-off hook instead: add a
-/// case here (and, if it leans on a new status kind like "dread" below, a
-/// case in StatusEffects.Update/DamageMultiplier too) for each new unique,
+/// Items.StatusChances. Each EffectId is a one-off hook instead: add a case
+/// here (and, if it leans on a new status kind like "dread" below, a case in
+/// StatusEffects.Update/DamageMultiplier too) for each new named effect,
 /// rather than trying to force every future effect into the generic
 /// chance-dictionary shape that's shared across ordinary items.
+///
+/// A weapon can list more than one EffectId -- OnPlayerHit runs every one of
+/// them on every non-killing hit, so e.g. Bow of Dread stacks a
+/// crowd-control effect (dread_on_hit) and a sustain effect
+/// (dread_lifesteal) on the same item, neither aware the other exists.
 /// </summary>
 public static class UniqueEffects
 {
-    /// <summary>Called from GameSession.HandleDamagingEnemies right alongside StatusEffects.RollPlayerHit, once per non-killing hit, only when the equipped weapon has an EffectId.</summary>
-    public static void OnPlayerHit(Enemy enemy, Bullet bullet, ItemDrop weapon, Random? rng = null)
+    /// <summary>Called from GameSession.HandleDamagingEnemies right alongside StatusEffects.RollPlayerHit, once per non-killing hit, only when the equipped weapon has at least one EffectId.</summary>
+    public static void OnPlayerHit(Enemy enemy, Bullet bullet, ItemDrop weapon, RunState state, Random? rng = null)
     {
         rng ??= Random.Shared;
-        switch (weapon.Definition.EffectId)
+        foreach (var effectId in weapon.Definition.EffectIds ?? Array.Empty<string>())
         {
-            case "dread_on_hit":
-                // Roughly 1-in-5 hits (better than 1-in-3 on a crit) afflict
-                // Dread: a strong slow plus +15% damage taken for 3.5s -- see
-                // StatusEffects.Update's "dread" case for the slow and
-                // DamageMultiplier's for the damage-taken bonus.
-                double chance = bullet.IsCritical ? .32 : .18;
-                if (rng.NextDouble() <= chance)
-                    StatusEffects.Apply(enemy, "dread", duration: 3.5, potency: .55);
-                break;
+            switch (effectId)
+            {
+                case "dread_on_hit":
+                    // Roughly 1-in-5 hits (better than 1-in-3 on a crit) afflict
+                    // Dread: a strong slow plus +15% damage taken for 3.5s -- see
+                    // StatusEffects.Update's "dread" case for the slow and
+                    // DamageMultiplier's for the damage-taken bonus.
+                    double dreadChance = bullet.IsCritical ? .32 : .18;
+                    if (rng.NextDouble() <= dreadChance)
+                        StatusEffects.Apply(enemy, "dread", duration: 3.5, potency: .55);
+                    break;
+
+                case "dread_lifesteal":
+                    // A second, independent effect on the same weapon: a 10%
+                    // chance per hit to heal the player for 2% of that hit's
+                    // damage. Doesn't touch dread_on_hit's roll or state at all --
+                    // that's the point of listing effects separately instead of
+                    // cramming multiple behaviors into one case.
+                    if (rng.NextDouble() <= .10)
+                    {
+                        int heal = Math.Max(1, (int)Math.Round(bullet.Damage * .02));
+                        state.HealthPoints = Math.Min(state.MaxHealthPoints, state.HealthPoints + heal);
+                    }
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `ItemDefinition.EffectId` (singular) → `EffectIds` (list). `UniqueEffects.OnPlayerHit` now iterates every id a weapon has and dispatches each independently through the same switch, so one item can carry several unrelated effects instead of just one.
- `OnPlayerHit` also now takes `RunState`, since an effect might need to touch player state (not just the enemy) — needed for the new lifesteal effect below.
- **Bow of Dread** now has two: the existing `dread_on_hit` (slow + damage-taken debuff) plus a new `dread_lifesteal` (10% chance per hit to heal 2% of that hit's damage) — added as the concrete proof that stacking actually works, not just plumbing.
- Carried Grimsbane's existing placeholder entry over to the new `EffectIds` list syntax (its actual effect is still unimplemented — same as before).
- `GameSession.HandleDamagingEnemies`'s dispatch check updated to `Definition.EffectIds.Count: > 0` and passes `State` through.

## Test plan
- [x] `dotnet build` (both projects) — clean
- [x] `dotnet test` — 433/433 passing, including a new test that hits Bow of Dread 200 times and asserts *both* effects fired from the same weapon in the same run

🤖 Generated with [Claude Code](https://claude.com/claude-code)