### PR TITLE
Fix Attack Speed display, dummy status effects, and tooltip overflow

### DIFF
--- a/RotBoiRemastered.Tests/Systems/EquipmentBalanceTests.cs
+++ b/RotBoiRemastered.Tests/Systems/EquipmentBalanceTests.cs
@@ -59,6 +59,39 @@ public class EquipmentBalanceTests : IDisposable
     }
 
     [Fact]
+    public void Grimsbane_CarriesBleed_AtFullFixedUniquePower()
+    {
+        var grimsbane = new ItemDrop(Items.UniquesByName["Grimsbane"], "Unique");
+        // Unique power is always fixed at 1.0 (see Items.RarityPower), so
+        // whatever bleed chance is authored on Grimsbane comes through
+        // unscaled -- no Epic/Legendary roll to account for like a regular
+        // item's StatusChances would need. Reads the authored chance rather
+        // than hardcoding it, so this stays valid as that number gets tuned.
+        double authoredChance = grimsbane.Definition.StatusChances!["bleed"];
+        Assert.Equal(authoredChance, Items.StatusChances(new ItemDrop?[] { grimsbane }).GetValueOrDefault("bleed"));
+    }
+
+    [Fact]
+    public void Grimsbane_AttackSpeedModifier_IsFasterNotSlower()
+    {
+        // Grimsbane is authored as Mult("Attack Speed", 200) -- a number well
+        // above the neutral 100, meant to read as "attacks twice as fast".
+        // Because Attack Speed is stored internally as a cooldown (smaller =
+        // faster), a broken Mult() that forgets to take the reciprocal would
+        // silently produce a *slower* weapon instead, exactly the "-50%
+        // instead of +100%" bug this guards against. Reads the effect
+        // straight off Grimsbane's own definition rather than duplicating
+        // Mult()'s formula, so it stays valid as the authored number is
+        // retuned -- only the sign/direction is pinned, not the magnitude.
+        var grimsbane = new ItemDrop(Items.UniquesByName["Grimsbane"], "Unique");
+        var attackSpeed = Items.Effects(grimsbane).Single(e => e.Stat == "Attack Speed");
+
+        Assert.True(attackSpeed.Multiplier < 1, $"A weapon authored with Attack Speed above 100 should have a shorter (sub-1) cooldown ratio, but was {attackSpeed.Multiplier}.");
+        Assert.True(attackSpeed.IsBeneficial);
+        Assert.StartsWith("+", attackSpeed.DisplayValue);
+    }
+
+    [Fact]
     public void Defense_NeverExceedsNinety_EvenWithPlateAndUpgradeStacks()
     {
         var state = new RunState();

--- a/RotBoiRemastered.Tests/Systems/ItemsTests.cs
+++ b/RotBoiRemastered.Tests/Systems/ItemsTests.cs
@@ -56,9 +56,33 @@ public class ItemsTests
     [Fact]
     public void AttackSpeedDisplay_TreatsShorterDelayAsPositive()
     {
-        Assert.Equal("+4%", new ItemEffectView("Attack Speed", 0, .96).DisplayValue);
+        // Multiplier is a cooldown ratio for Attack Speed (smaller = faster);
+        // DisplayValue inverts it to the actual speed ratio before turning
+        // that into a percent, so a .96 cooldown ratio (attacks 1/.96 =
+        // 1.041666...x as often) reads as "+4.17%", not the raw "+4%" you'd
+        // get by applying (1 - Multiplier) * 100 directly to the ratio.
+        Assert.Equal("+4.17%", new ItemEffectView("Attack Speed", 0, .96).DisplayValue);
         Assert.True(new ItemEffectView("Attack Speed", -3, 1).IsBeneficial);
-        Assert.Equal("-10%", new ItemEffectView("Attack Speed", 0, 1.10).DisplayValue);
+        Assert.Equal("-9.09%", new ItemEffectView("Attack Speed", 0, 1.10).DisplayValue);
+    }
+
+    [Fact]
+    public void AttackSpeedMult_ReciprocalAndDisplayValue_StayInLockstep()
+    {
+        // Regression test: Items.Mult("Attack Speed", percent) is documented to
+        // store 100/percent as the cooldown ratio (so "200" means attacking
+        // twice as fast), and ItemEffectView.DisplayValue is documented to
+        // un-invert that same ratio before turning it into a percent. These
+        // two have already drifted out of sync once in practice -- Mult()
+        // reverted to the plain percent/100 form while DisplayValue still
+        // expected the inverted ratio, which silently turned a "200" (meant
+        // to double attack speed) into a displayed "-50%" that actually
+        // halved it. Mult() itself is private, so this pins its documented
+        // output (100/200 = .5) directly and checks DisplayValue interprets
+        // that ratio as "attacks twice as fast", not "half as fast".
+        var doubledAttackSpeed = new ItemEffectView("Attack Speed", 0, 100.0 / 200.0);
+        Assert.Equal("+100%", doubledAttackSpeed.DisplayValue);
+        Assert.True(doubledAttackSpeed.IsBeneficial);
     }
 
     [Fact]

--- a/RotBoiRemastered.Tests/Systems/UniqueEffectsTests.cs
+++ b/RotBoiRemastered.Tests/Systems/UniqueEffectsTests.cs
@@ -7,6 +7,7 @@ namespace RotBoiRemastered.Tests.Systems;
 public class UniqueEffectsTests
 {
     private static ItemDrop BowOfDread() => new(Items.UniquesByName["Bow of Dread"], "Unique");
+    private static ItemDrop Grimsbane() => new(Items.UniquesByName["Grimsbane"], "Unique");
 
     private static Bullet TestBullet(bool isCritical) =>
         new(0, 0, speed: 1, direction: 0, bulletRange: 100, size: 10, Color.White, pierce: 1, damage: 10, isCritical);
@@ -48,6 +49,38 @@ public class UniqueEffectsTests
 
         Assert.True(boss.StatusEffects.ContainsKey("dread"), "dread_on_hit should have procced at least once in 200 hits.");
         Assert.True(state.HealthPoints > 500, "dread_lifesteal should have healed the player at least once in 200 hits.");
+    }
+
+    [Fact]
+    public void OnPlayerHit_StacksBaneOnEveryHit_NoRollNeeded()
+    {
+        // Unlike Dread's chance-based procs, bane_on_hit is Grimsbane's
+        // guaranteed signature effect -- every single hit adds a stack.
+        var boss = new Beaudis(0, 0, 100, new Random(4));
+        var weapon = Grimsbane();
+        var state = new RunState();
+
+        UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: false), weapon, state, new Random(1));
+
+        var bane = Assert.Single(boss.StatusEffects);
+        Assert.Equal("bane", bane.Key);
+        Assert.Equal(1, bane.Value.Stacks);
+        Assert.Equal(1.05, StatusEffects.DamageMultiplier(boss));
+    }
+
+    [Fact]
+    public void OnPlayerHit_CapsBaneStacksAtThirty()
+    {
+        var boss = new Beaudis(0, 0, 100, new Random(4));
+        var weapon = Grimsbane();
+        var state = new RunState();
+        var rng = new Random(1);
+
+        for (int i = 0; i < 40; i++)
+            UniqueEffects.OnPlayerHit(boss, TestBullet(isCritical: false), weapon, state, rng);
+
+        Assert.Equal(30, boss.StatusEffects["bane"].Stacks);
+        Assert.Equal(2.50, StatusEffects.DamageMultiplier(boss), precision: 6);
     }
 
     [Fact]

--- a/RotBoiRemastered.Tests/UI/SoulHubTests.cs
+++ b/RotBoiRemastered.Tests/UI/SoulHubTests.cs
@@ -1,9 +1,13 @@
 using Microsoft.Xna.Framework;
 using RotBoiRemastered.Core;
+using RotBoiRemastered.Entities;
+using RotBoiRemastered.Systems;
 using RotBoiRemastered.UI;
+using RotBoiRemastered.World;
 
 namespace RotBoiRemastered.Tests.UI;
 
+[Collection("GameProfileState")]
 public sealed class SoulHubTests
 {
     [Fact]
@@ -15,5 +19,49 @@ public sealed class SoulHubTests
 
         Assert.True(SoulHub.WithinStationRadius(justInside, station, 1.85f));
         Assert.False(SoulHub.WithinStationRadius(justOutside, station, 1.85f));
+    }
+
+    [Fact]
+    public void Update_LetsGrimsbaneStackBaneOnTheDummy_NotJustRawBulletDamage()
+    {
+        // Regression test: the DPS dummy used to be a bare world position with
+        // no Enemy/StatusEffects state, so status effects (bleed, bane, dread,
+        // ...) and unique on-hit effects could never land on it -- only the
+        // bullet's raw, un-modified damage counted. SoulHub.Update now routes
+        // dummy hits through StatusEffects.RollPlayerHit/UniqueEffects.OnPlayerHit
+        // exactly like a real enemy would (see SoulHub's TrainingDummy field).
+        var session = new GameSession(Battleground.GenerateSound(), 1280, 720, new Random(1));
+        var grimsbane = new ItemDrop(Items.UniquesByName["Grimsbane"], "Unique");
+        session.State.SetEquipment(new Dictionary<string, ItemDrop?> { ["weapon"] = grimsbane });
+        var soulHub = new SoulHub();
+        soulHub.Enter(session);
+
+        var bullet = new Bullet(soulHub.DummyWorld.X, soulHub.DummyWorld.Y, speed: 0, direction: 0,
+            bulletRange: 100, size: 10, Color.White, pierce: 1, damage: 10, isCritical: false);
+        session.State.BulletHolster.Add(bullet);
+
+        soulHub.Update(session, 1.0 / 60);
+
+        Assert.True(soulHub.DummyHasStatus("bane"), "bane_on_hit should stack on every hit, with no roll needed.");
+        Assert.True(soulHub.CurrentDps > 0);
+    }
+
+    [Fact]
+    public void TrainingDummy_BleedTicks_ScaleFromBossTierHp_NotMillions()
+    {
+        // Regression test: the dummy used to be built with a billion-HP pool
+        // to make it "unkillable" for the DPS meter, but StatusEffects.Update's
+        // bleed DoT scales off enemy.MaxHp (percent-of-max-health per stack)
+        // -- against that billion-HP pool, a handful of bleed stacks ticked
+        // for millions of damage per second instead of a boss-realistic
+        // amount. TrainingDummy is unkillable via its TakeDamage override
+        // resetting Hp every hit, not via an inflated MaxHp, so this should
+        // never regress back to that scale.
+        var dummy = new TrainingDummy(0, 0);
+        StatusEffects.Apply(dummy, "bleed", duration: 3.2, potency: .006, stacks: 8);
+
+        StatusEffects.Update(dummy, 1.0);
+
+        Assert.True(dummy.UnrecordedDamage < 5000, $"Expected boss-realistic bleed damage for one second at 8 stacks, got {dummy.UnrecordedDamage}.");
     }
 }

--- a/RotBoiRemastered/Entities/TrainingDummy.cs
+++ b/RotBoiRemastered/Entities/TrainingDummy.cs
@@ -1,0 +1,50 @@
+using Microsoft.Xna.Framework;
+
+namespace RotBoiRemastered.Entities;
+
+/// <summary>
+/// The Soul hub's stationary DPS target. A real Enemy (not just a world
+/// position) so it can carry the same StatusEffects dictionary every other
+/// enemy does -- that's what lets bleed/bane/poison ticks and on-hit unique
+/// effects actually land on it via the normal StatusEffects/UniqueEffects
+/// pipeline, instead of the dummy silently only ever taking raw bullet
+/// damage. Effectively unkillable: TakeDamage records the hit for SoulHub's
+/// DPS meter (see DrainUnrecordedDamage) and resets Hp back to MaxHp rather
+/// than letting it reach zero.
+/// </summary>
+public sealed class TrainingDummy : Enemy
+{
+    public double UnrecordedDamage { get; private set; }
+
+    /// <summary>
+    /// Boss-tier HP (matches Beaudis's 26,000), not some enormous "surely
+    /// never runs out" number -- StatusEffects.Update's bleed/poison DoT
+    /// ticks scale off enemy.MaxHp (percent-of-max-health per stack), so an
+    /// artificially huge MaxHp made bleed/poison ticks explode into millions
+    /// of damage per proc instead of the modest, boss-realistic numbers a
+    /// DPS dummy should show. TakeDamage below is what actually makes this
+    /// dummy unkillable (it resets Hp to MaxHp every hit) -- MaxHp itself
+    /// only needs to be a believable enemy HP pool, not a huge one.
+    /// </summary>
+    public TrainingDummy(float worldX, float worldY)
+        : base(worldX, worldY, speed: 0, size: 68, Color.White, damage: 0, hp: 26_000,
+            expValue: 0, difficulty: 0, awarenessRange: 0)
+    {
+    }
+
+    public override HitResult TakeDamage(double amount, string partId = "body", DamageSource source = DamageSource.Direct)
+    {
+        int rounded = Math.Max(0, (int)Math.Round(amount));
+        UnrecordedDamage += rounded;
+        Hp = MaxHp;
+        return new HitResult(true, false, rounded);
+    }
+
+    /// <summary>Pulls and clears whatever damage has landed (direct hits or status-effect ticks) since the last drain, for SoulHub to fold into its DPS window.</summary>
+    public double DrainUnrecordedDamage()
+    {
+        double amount = UnrecordedDamage;
+        UnrecordedDamage = 0;
+        return amount;
+    }
+}

--- a/RotBoiRemastered/Systems/Items.cs
+++ b/RotBoiRemastered/Systems/Items.cs
@@ -46,13 +46,22 @@ public sealed record ItemEffectView(string Stat, double Additive, double Multipl
     {
         get
         {
-            double direction = Stat == "Attack Speed" ? -1 : 1;
             if (Math.Abs(Additive) > .0001)
             {
+                double direction = Stat == "Attack Speed" ? -1 : 1;
                 double value = Additive * direction;
                 return $"{(value >= 0 ? "+" : "")}{value.ToString("0.##", CultureInfo.InvariantCulture)}";
             }
-            double percent = (Multiplier - 1) * 100 * direction;
+            // Multiplier is a cooldown ratio for Attack Speed (smaller means
+            // a shorter cooldown, i.e. faster attacks) -- invert it to the
+            // actual speed ratio before expressing a percent, so a halved
+            // cooldown (Multiplier .5, from Items.Mult("Attack Speed", 200))
+            // reads as "+100%" (twice the attack rate) instead of the raw,
+            // mathematically wrong "+50%" you'd get by applying the same
+            // percent-off-1.0 formula every other stat uses directly to a
+            // cooldown ratio instead of a rate.
+            double speedRatio = Stat == "Attack Speed" ? 1.0 / Multiplier : Multiplier;
+            double percent = (speedRatio - 1) * 100;
             return $"{(percent >= 0 ? "+" : "")}{percent.ToString("0.##", CultureInfo.InvariantCulture)}%";
         }
     }
@@ -74,7 +83,24 @@ public static class Items
         new[] { "weapon", "armor", "ring", "accessory" };
 
     private static ItemStatModifier Add(string stat, double value) => new(stat, Additive: value);
-    private static ItemStatModifier Mult(string stat, double value) => new(stat, Multiplier: value);
+    /// <summary>
+    /// Takes a percentage, not a raw ratio -- Mult("Bullet Range", 78) means
+    /// 78% (0.78x). "Attack Speed" is the one exception: it's stored as a
+    /// frame-count cooldown internally (see RunState.AttackCooldownStat),
+    /// where a *smaller* ratio means a shorter cooldown and therefore
+    /// *faster* attacks -- backwards from what "200 attack speed" should
+    /// intuitively mean. So Attack Speed alone takes the reciprocal
+    /// (100/percent) instead of percent/100, making Mult("Attack Speed", 200)
+    /// mean "attacks twice as fast" like every other stat's bigger-is-better
+    /// convention. ItemEffectView.DisplayValue un-inverts this same way when
+    /// showing the tooltip percentage -- if you ever touch one of these two,
+    /// touch the other, or they'll silently disagree (this has already
+    /// happened once: this method reverted to the plain percent/100 form
+    /// while DisplayValue still expected the inverted ratio, which made
+    /// Mult("Attack Speed", 200) display as -50% instead of +100%).
+    /// </summary>
+    private static ItemStatModifier Mult(string stat, double percent) =>
+        new(stat, Multiplier: stat == "Attack Speed" ? 100.0 / percent : percent / 100.0);
     private static IReadOnlyList<ItemStatModifier> Mods(params ItemStatModifier[] modifiers) => modifiers;
     private static IReadOnlyDictionary<string, double> Status(string kind, double chance) =>
         new Dictionary<string, double> { [kind] = chance };
@@ -87,58 +113,58 @@ public static class Items
     public static readonly IReadOnlyList<ItemDefinition> Definitions = new[]
     {
         new ItemDefinition("Iron Dagger", "weapon", "Close enough to hear the cut.", "dagger",
-            Mods(Mult("Bullet Damage", 2.10), Mult("Bullet Range", .28), Mult("Attack Speed", .78))),
+            Mods(Mult("Bullet Damage", 210), Mult("Bullet Range", 28), Mult("Attack Speed", 128))),
         new ItemDefinition("Bloody Dagger", "weapon", "It remembers every hand that slipped.", "dagger",
-            Mods(Mult("Bullet Damage", 1.82), Mult("Bullet Range", .32), Mult("Attack Speed", .82)), Status("bleed", .20)),
+            Mods(Mult("Bullet Damage", 182), Mult("Bullet Range", 32), Mult("Attack Speed", 122)), Status("bleed", .20)),
         new ItemDefinition("Rusty Sword", "weapon", "The ruined edge asks for many swings.", "sword",
-            Mods(Mult("Bullet Damage", .62), Mult("Bullet Range", .58), Mult("Attack Speed", .46))),
+            Mods(Mult("Bullet Damage", 62), Mult("Bullet Range", 58), Mult("Attack Speed", 217))),
         new ItemDefinition("Iron Sword", "weapon", "A dependable answer at arm's length.", "sword",
-            Mods(Mult("Bullet Damage", 1.55), Mult("Bullet Range", .62), Mult("Attack Speed", .94))),
+            Mods(Mult("Bullet Damage", 155), Mult("Bullet Range", 62), Mult("Attack Speed", 106))),
         new ItemDefinition("Bloody Sword", "weapon", "Warm stains bead along the fuller.", "sword",
-            Mods(Mult("Bullet Damage", 1.38), Mult("Bullet Range", .65), Mult("Attack Speed", .90)), Status("bleed", .16)),
+            Mods(Mult("Bullet Damage", 138), Mult("Bullet Range", 65), Mult("Attack Speed", 111)), Status("bleed", .16)),
         new ItemDefinition("Iron Spear", "weapon", "Distance, leverage, and one clean line.", "spear",
-            Mods(Mult("Bullet Damage", 1.28), Mult("Bullet Range", 1.02), Mult("Attack Speed", 1.10), Add("Bullet Pierce", .60))),
+            Mods(Mult("Bullet Damage", 128), Mult("Bullet Range", 102), Mult("Attack Speed", 91), Add("Bullet Pierce", .60))),
         new ItemDefinition("Bone Spear", "weapon", "A pale point made for finding gaps.", "spear",
-            Mods(Mult("Bullet Damage", 1.16), Mult("Bullet Range", 1.08), Add("Crit Chance", .08), Add("Bullet Pierce", .40))),
+            Mods(Mult("Bullet Damage", 116), Mult("Bullet Range", 108), Add("Crit Chance", .08), Add("Bullet Pierce", .40))),
         new ItemDefinition("Hunting Bow", "weapon", "The string hums before danger arrives.", "bow",
-            Mods(Mult("Bullet Damage", .92), Mult("Bullet Range", 1.72), Mult("Bullet Speed", 1.28), Mult("Attack Speed", .88))),
+            Mods(Mult("Bullet Damage", 92), Mult("Bullet Range", 172), Mult("Bullet Speed", 128), Mult("Attack Speed", 114))),
         new ItemDefinition("Yew Longbow", "weapon", "Patience drawn into a distant point.", "bow",
-            Mods(Mult("Bullet Damage", .98), Mult("Bullet Range", 2.02), Mult("Bullet Speed", 1.42), Mult("Attack Speed", 1.18))),
+            Mods(Mult("Bullet Damage", 98), Mult("Bullet Range", 202), Mult("Bullet Speed", 142), Mult("Attack Speed", 85))),
         new ItemDefinition("Ash Wand", "weapon", "A faint ember reaches beyond the dark.", "wand",
-            Mods(Mult("Bullet Damage", .72), Mult("Bullet Range", 2.55), Mult("Bullet Speed", 1.34), Mult("Bullet Size", .82))),
+            Mods(Mult("Bullet Damage", 72), Mult("Bullet Range", 255), Mult("Bullet Speed", 134), Mult("Bullet Size", 82))),
         new ItemDefinition("Glass Wand", "weapon", "Fragile light travels farther than courage.", "wand",
-            Mods(Mult("Bullet Damage", .64), Mult("Bullet Range", 3.00), Mult("Bullet Speed", 1.55), Add("Crit Chance", .12))),
+            Mods(Mult("Bullet Damage", 64), Mult("Bullet Range", 300), Mult("Bullet Speed", 155), Add("Crit Chance", .12))),
 
         new ItemDefinition("Leather Vest", "armor", "Scuffed hide that leaves room to breathe.", "vest",
-            Mods(Add("Defense", 18), Mult("Player Speed", 1.08))),
+            Mods(Add("Defense", 18), Mult("Player Speed", 108))),
         new ItemDefinition("Bloodstained Garb", "armor", "The cloth refuses to let another drop fall.", "vest",
-            Mods(Add("Defense", 24), Add("Vitality", 12), Mult("Player Speed", 1.03))),
+            Mods(Add("Defense", 24), Add("Vitality", 12), Mult("Player Speed", 103))),
         new ItemDefinition("Chainmail", "armor", "Linked rings trade a little speed for certainty.", "chain",
-            Mods(Add("Defense", 42), Mult("Player Speed", .92))),
+            Mods(Add("Defense", 42), Mult("Player Speed", 92))),
         new ItemDefinition("Plate Armor", "armor", "A walking wall, heavy but never absolute.", "plate",
-            Mods(Add("Defense", 76), Mult("Player Speed", .78))),
+            Mods(Add("Defense", 76), Mult("Player Speed", 78))),
         new ItemDefinition("Rusty Plate", "armor", "Missing rivets make the old shell surprisingly nimble.", "plate",
-            Mods(Add("Defense", 55), Mult("Player Speed", .90))),
+            Mods(Add("Defense", 55), Mult("Player Speed", 90))),
 
         new ItemDefinition("Copper Ring", "ring", "A warm band that keeps the hands moving.", "band",
-            Mods(Mult("Attack Speed", .88))),
+            Mods(Mult("Attack Speed", 114))),
         new ItemDefinition("Silver Band", "ring", "Cold metal steadies a hurried aim.", "band",
-            Mods(Add("Crit Chance", .10), Mult("Bullet Speed", 1.12))),
+            Mods(Add("Crit Chance", .10), Mult("Bullet Speed", 112))),
         new ItemDefinition("Signet Ring", "ring", "A forgotten crest still carries authority.", "signet",
-            Mods(Mult("Bullet Damage", 1.16), Add("Defense", 8))),
+            Mods(Mult("Bullet Damage", 116), Add("Defense", 8))),
         new ItemDefinition("Thorn Ring", "ring", "Its tiny barbs promise that wounds linger.", "signet",
             Mods(Add("Crit Chance", .05)), Status("bleed", .08)),
 
         new ItemDefinition("Lucky Charm", "accessory", "Small enough to lose; stubborn enough to return.", "charm",
-            Mods(Add("Crit Chance", .08), Mult("Exp Multiplier", 1.12))),
+            Mods(Add("Crit Chance", .08), Mult("Exp Multiplier", 112))),
         new ItemDefinition("Old Locket", "accessory", "The portrait is gone, but the promise remains.", "locket",
             Mods(Add("Health", 120), Add("Vitality", 8))),
         new ItemDefinition("Traveler's Badge", "accessory", "Every scratch points toward another road.", "badge",
-            Mods(Mult("Player Speed", 1.10), Add("Aura Size", 14))),
+            Mods(Mult("Player Speed", 110), Add("Aura Size", 14))),
         new ItemDefinition("Venom Vial", "accessory", "A green drop waits behind thin glass.", "vial",
-            Mods(Mult("Bullet Damage", .94)), Status("poison", .15)),
+            Mods(Mult("Bullet Damage", 94)), Status("poison", .15)),
         new ItemDefinition("Frost Bell", "accessory", "Its silent note makes the world hesitate.", "bell",
-            Mods(Mult("Bullet Range", 1.10)), Status("slow", .14)),
+            Mods(Mult("Bullet Range", 110)), Status("slow", .14)),
     };
 
     public static readonly IReadOnlyDictionary<string, ItemDefinition> DefinitionsByName =
@@ -156,17 +182,18 @@ public static class Items
         //Template for new unique items -- list one or more EffectIds to stack independent effects on the same item (see UniqueEffects.OnPlayerHit):
         /*
         new ItemDefinition("Unique Name", "weapon/armor/ring/accessory", "Flavor text.",
-            "type_visual (vial/bow/dagger/bell/badge/etc.)", Mods(Mult("Bullet Damage", 0.00), Mult("Bullet Range", 0.00), Mult("Bullet Speed", 0.00)),
+            "type_visual (vial/bow/dagger/bell/badge/etc.)", Mods(Mult("Bullet Damage", 100), Mult("Bullet Range", 100), Mult("Bullet Speed", 100)),
             EffectIds: new[] { "custom_effect_name", "second_effect_name" }, DropsFromBossKey: "boss_key", DropChance: .12),
         */
 
         new ItemDefinition("Bow of Dread", "weapon", "Every arrow carries a whisper of Dread, leaving struck enemies slowed and exposed -- and the bow itself feeds on the fear it causes.",
-            "bow", Mods(Mult("Bullet Damage", 1.35), Mult("Bullet Range", 1.85), Mult("Bullet Speed", 1.20)),
+            "bow", Mods(Mult("Bullet Damage", 135), Mult("Bullet Range", 185), Mult("Bullet Speed", 120)),
             EffectIds: new[] { "dread_on_hit", "dread_lifesteal" }, DropsFromBossKey: "sting", DropChance: .12),
 
-        new ItemDefinition("Grimsbane", "weapon", "Darkness clings to the rigid bones, and the shadows it strikes shiver in fear.",
-            "bow", Mods(Mult("Bullet Damage", 1.20), Mult("Bullet Range", .35), Mult("Attack Speed", .85)),
-            EffectIds: new[] { "grimsbane_effect" }, DropsFromBossKey: "dissonance", DropChance: .12),
+        new ItemDefinition("Grimsbane", "weapon",
+            "Darkness clings to the rigid bones, and the shadows it strikes shiver in fear. Every hit marks its target with Bane, a stacking curse that leaves it ever more exposed.",
+            "bow", Mods(Mult("Bullet Damage", 50), Mult("Bullet Range", 200), Mult("Attack Speed", 200)), Status("bleed", .05),
+            EffectIds: new[] { "bane_on_hit" }, DropsFromBossKey: "dissonance", DropChance: .12),
 
     };
 

--- a/RotBoiRemastered/Systems/StatusEffects.cs
+++ b/RotBoiRemastered/Systems/StatusEffects.cs
@@ -32,7 +32,8 @@ public static class StatusEffects
         }
         effect.Remaining = Math.Max(effect.Remaining, duration);
         effect.Potency = Math.Max(effect.Potency, potency);
-        effect.Stacks = Math.Min(kind == "bleed" ? 8 : 3, effect.Stacks + stacks);
+        int stackCap = kind switch { "bleed" => 8, "bane" => 30, _ => 3 };
+        effect.Stacks = Math.Min(stackCap, effect.Stacks + stacks);
         GameProfile.IncrementQuest("statuses_applied");
     }
 
@@ -65,6 +66,11 @@ public static class StatusEffects
             multiplier += .15;
         if (bullet?.IsCritical == true && enemy.StatusEffects.TryGetValue("bleed", out var bleed))
             multiplier += Math.Min(.20, bleed.Stacks * .025);
+        // Unlike bleed's crit-only bonus, Bane (Grimsbane's signature stacking
+        // curse -- see UniqueEffects.OnPlayerHit's "bane_on_hit") boosts every
+        // hit the target takes, +5% per stack, up to the 30-stack cap (+150%).
+        if (enemy.StatusEffects.TryGetValue("bane", out var bane))
+            multiplier += bane.Stacks * .05;
         return multiplier;
     }
 

--- a/RotBoiRemastered/Systems/UniqueEffects.cs
+++ b/RotBoiRemastered/Systems/UniqueEffects.cs
@@ -50,6 +50,17 @@ public static class UniqueEffects
                         state.HealthPoints = Math.Min(state.MaxHealthPoints, state.HealthPoints + heal);
                     }
                     break;
+
+                case "bane_on_hit":
+                    // Every hit (no roll -- this is Grimsbane's guaranteed
+                    // signature effect, unlike Dread's chance-based procs)
+                    // stacks Bane by 1, each stack worth +5% damage taken
+                    // (see StatusEffects.DamageMultiplier's "bane" case) up
+                    // to StatusEffects' 30-stack cap for that kind. The 4s
+                    // duration refreshes on every hit, so sustained fire
+                    // keeps racking stacks up but stopping lets them decay.
+                    StatusEffects.Apply(enemy, "bane", duration: 4.0);
+                    break;
             }
         }
     }

--- a/RotBoiRemastered/UI/InformationSheet.cs
+++ b/RotBoiRemastered/UI/InformationSheet.cs
@@ -678,24 +678,17 @@ public sealed class InformationSheet
         return new Rectangle(x, y, rect.Width, rect.Height);
     }
 
-    private void DrawTooltip(SpriteBatch spriteBatch, Point mousePosition)
+    /// <summary>Breaks text into lines no wider than maxWidth at fontSize, so callers can size a panel to the wrapped line count before drawing rather than letting long text run past a fixed-height box.</summary>
+    private List<string> WrapText(string text, double fontSize, int maxWidth)
     {
-        if (_tooltipItem is not null)
-        {
-            DrawItemTooltip(spriteBatch, mousePosition, _tooltipItem);
-            return;
-        }
-        if (string.IsNullOrEmpty(_tooltip))
-            return;
-        int width = Math.Min(Px(250), (int)(_screenWidth * .24));
-        var font = UiTheme.RawFont(Px(9) * LocalTextScale());
-        var words = _tooltip.Split(' ');
+        var font = UiTheme.RawFont(fontSize * LocalTextScale());
+        var words = text.Split(' ');
         var lines = new List<string>();
         string line = "";
         foreach (var word in words)
         {
             string candidate = (line + " " + word).Trim();
-            if (font.MeasureString(candidate).X > width - Px(18) && line.Length > 0)
+            if (font.MeasureString(candidate).X > maxWidth && line.Length > 0)
             {
                 lines.Add(line);
                 line = word;
@@ -706,6 +699,20 @@ public sealed class InformationSheet
             }
         }
         lines.Add(line);
+        return lines;
+    }
+
+    private void DrawTooltip(SpriteBatch spriteBatch, Point mousePosition)
+    {
+        if (_tooltipItem is not null)
+        {
+            DrawItemTooltip(spriteBatch, mousePosition, _tooltipItem);
+            return;
+        }
+        if (string.IsNullOrEmpty(_tooltip))
+            return;
+        int width = Math.Min(Px(250), (int)(_screenWidth * .24));
+        var lines = WrapText(_tooltip, Px(9), width - Px(18));
         var rect = new Rectangle(mousePosition.X - width - Px(10), mousePosition.Y + Px(10), width, Px(15 + lines.Count * 14));
         rect = ClampToBounds(rect, new Rectangle(_posX, 0, _totalLength, _totalHeight));
         UiTheme.DrawPanel(spriteBatch, rect, UiTheme.PanelRaised, UiTheme.Cream, shadow: 4);
@@ -721,7 +728,12 @@ public sealed class InformationSheet
         int width = Math.Min(Px(320), (int)(_screenWidth * .34));
         int headerHeight = Px(74);
         int rowHeight = Px(38);
-        int height = headerHeight + effects.Count * rowHeight + statuses.Count * Px(30) + Px(48);
+        // Wrapped up front (rather than drawn at a fixed one-line height) so
+        // long flavor text -- e.g. Grimsbane's -- breaks onto extra lines
+        // instead of running past the panel's right edge, and the panel is
+        // sized to actually fit however many lines that took.
+        var descriptionLines = WrapText($"“{item.Definition.Description}”", Px(10), width - Px(30));
+        int height = headerHeight + effects.Count * rowHeight + statuses.Count * Px(30) + Px(34) + descriptionLines.Count * Px(14);
         var rect = new Rectangle(mousePosition.X - width - Px(12), mousePosition.Y + Px(10), width, height);
         rect = ClampToBounds(rect, new Rectangle(0, 0, _screenWidth, _totalHeight));
         Color rarity = UiTheme.RarityColors.TryGetValue(item.Rarity, out var rarityColor) ? rarityColor : UiTheme.Border;
@@ -766,8 +778,9 @@ public sealed class InformationSheet
             y += Px(30);
         }
         Primitives2D.Line(spriteBatch, new Vector2(rect.X + Px(12), y), new Vector2(rect.Right - Px(12), y), UiTheme.Border, 1);
-        DrawSheetText(spriteBatch, $"“{item.Definition.Description}”", Px(10), UiTheme.Cream,
-            new Vector2(rect.X + Px(15), y + Px(12)));
+        for (int index = 0; index < descriptionLines.Count; index++)
+            DrawSheetText(spriteBatch, descriptionLines[index], Px(10), UiTheme.Cream,
+                new Vector2(rect.X + Px(15), y + Px(12) + index * Px(14)));
     }
 
     /// <summary>

--- a/RotBoiRemastered/UI/SoulHub.cs
+++ b/RotBoiRemastered/UI/SoulHub.cs
@@ -35,6 +35,7 @@ public sealed class SoulHub
     private readonly Dictionary<string, Vector2> _stationWorld = new();
     private readonly Dictionary<string, Vector2> _pathPortalWorld = new();
     private Vector2 _dummyWorld;
+    private TrainingDummy _dummy = new(0, 0);
     private string? _overlay;
     private string? _tooltip;
     private double _seconds;
@@ -55,6 +56,11 @@ public sealed class SoulHub
     public bool IsEnteringPortal => _enteringPortalKey is not null;
     /// <summary>Cosmetic player render scale (see Player.Draw) -- 1 outside the pull-in animation, easing down to PortalMinPlayerScale during it.</summary>
     public float PlayerDrawScale => _playerDrawScale;
+    /// <summary>World center of the DPS dummy's hit rect -- exposed so callers (and tests) can place bullets on it without duplicating its layout.</summary>
+    public Vector2 DummyWorld => _dummyWorld;
+    public double CurrentDps => _currentDps;
+    /// <summary>Whether the training dummy is currently carrying the given status effect (e.g. "bleed", "bane") -- lets tests confirm status effects actually land on it instead of only checking the DPS number they produce.</summary>
+    public bool DummyHasStatus(string kind) => _dummy.StatusEffects.ContainsKey(kind);
     public void CloseOverlay()
     {
         _overlay = null;
@@ -76,6 +82,7 @@ public sealed class SoulHub
         session.State.EnemyHolster.Clear();
         session.State.EnemyProjectileHolster.Clear();
         _dummyWorld = session.PlayerWorldCenter + new Vector2(Simulation.TileSize * 4, 0);
+        _dummy = new TrainingDummy(_dummyWorld.X, _dummyWorld.Y);
         _stationWorld.Clear();
         _stationWorld["storage"] = session.PlayerWorldCenter - new Vector2(Simulation.TileSize * 4, 0);
         _stationWorld["quests"] = session.PlayerWorldCenter - new Vector2(0, Simulation.TileSize * 4);
@@ -115,19 +122,19 @@ public sealed class SoulHub
         foreach (var bullet in session.State.BulletHolster.Where(bullet => !bullet.RemFlag && dummyRect.Intersects(bullet.WorldRect())).ToArray())
         {
             bullet.RemFlag = true;
-            if (_seconds - _lastHitTime > 2)
-            {
-                _dummyHits.Clear();
-                _measurementStart = _seconds;
-            }
-            double damage = bullet.Damage;
-            _dummyHits.Enqueue(new DummyHit(_seconds, damage));
-            _lastHitTime = _seconds;
-            session.State.DamageTextList.Add(new DamageText(_dummyWorld.X - 20, _dummyWorld.Y - 28,
-                bullet.IsCritical ? UiTheme.Purple : UiTheme.Gold, damage, 40, Simulation.FrameRate));
-            GameProfile.IncrementQuest("dummy_damage", Math.Max(1, (long)Math.Round(damage)));
+            double hitDamage = bullet.Damage * StatusEffects.DamageMultiplier(_dummy, bullet);
+            _dummy.TakeDamage(hitDamage);
+            RecordDummyHit(session, _dummy.DrainUnrecordedDamage(), bullet.IsCritical);
+            StatusEffects.RollPlayerHit(_dummy, bullet, session.State.Equipment.Values, session.State.ProjectileCount);
+            if (session.State.Equipment.GetValueOrDefault("weapon") is { Definition.EffectIds.Count: > 0 } weapon)
+                UniqueEffects.OnPlayerHit(_dummy, bullet, weapon, session.State);
         }
         session.State.BulletHolster.RemoveAll(bullet => bullet.RemFlag);
+        // Ticks bleed/poison/bane the same as a real enemy would every frame,
+        // so DoT from a hit-and-run playstyle keeps contributing to the DPS
+        // meter instead of only ever counting direct impacts.
+        StatusEffects.Update(_dummy, elapsedSeconds);
+        RecordDummyHit(session, _dummy.DrainUnrecordedDamage(), isCritical: false);
         while (_dummyHits.Count > 0 && _seconds - _dummyHits.Peek().Time > 5)
             _dummyHits.Dequeue();
         double observation = Math.Min(5, Math.Max(.5, _seconds - _measurementStart));
@@ -141,6 +148,23 @@ public sealed class SoulHub
             _lastRecordSave = _seconds;
         }
         session.UpdateDamageTexts();
+    }
+
+    /// <summary>Folds a landed hit (direct bullet impact or a status-effect tick) into the DPS window, damage text, and quest counter -- shared by both so bleed/bane ticks show up exactly like a direct hit would.</summary>
+    private void RecordDummyHit(GameSession session, double damage, bool isCritical)
+    {
+        if (damage <= 0)
+            return;
+        if (_seconds - _lastHitTime > 2)
+        {
+            _dummyHits.Clear();
+            _measurementStart = _seconds;
+        }
+        _dummyHits.Enqueue(new DummyHit(_seconds, damage));
+        _lastHitTime = _seconds;
+        session.State.DamageTextList.Add(new DamageText(_dummyWorld.X - 20, _dummyWorld.Y - 28,
+            isCritical ? UiTheme.Purple : UiTheme.Gold, damage, 40, Simulation.FrameRate));
+        GameProfile.IncrementQuest("dummy_damage", Math.Max(1, (long)Math.Round(damage)));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Re-fixed `Items.Mult`'s Attack Speed reciprocal (had silently reverted, causing "200" to display as -50% instead of +100%) and added regression tests pinning the Mult()/DisplayValue contract.
- The Soul hub's DPS practice dummy was a bare world position, not a real `Enemy`, so bleed/bane and unique on-hit effects (e.g. Grimsbane's Bane stacks) never actually landed on it. Added `TrainingDummy : Enemy` and routed `SoulHub.Update`'s hits through the normal `StatusEffects`/`UniqueEffects` pipeline.
- The dummy's placeholder billion-HP pool made bleed's percent-of-max-health DoT formula explode into millions of damage per tick (~10-20k per frame). Dropped it to a boss-tier HP value (26,000, matching Beaudis) since `TakeDamage`'s override — not a huge HP number — is what actually makes it unkillable.
- Long item flavor text (e.g. Grimsbane's) was drawn as a single unwrapped line and overflowed the tooltip panel. `InformationSheet.DrawItemTooltip` now wraps the description and sizes the panel to the wrapped line count.

## Test plan
- [x] `dotnet build RotBoiRemastered.Tests`
- [x] `dotnet test RotBoiRemastered.Tests` — 442/442 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)