### PR TITLE
Move dev keybinds into the console

### DIFF
--- a/RotBoiRemastered/Core/RotBoiGame.cs
+++ b/RotBoiRemastered/Core/RotBoiGame.cs
@@ -266,8 +266,6 @@ public class RotBoiGame : Game
     /// <summary>Ported from main.py's update_input_toggles().</summary>
     private void UpdateInputToggles()
     {
-        if (Keybinds.Pressed("dev_boss") && _session is not null && _session.State.ActiveBoss is null && !_session.State.BossDebugRequested)
-            _session.State.BossDebugRequested = true;
         if (Keybinds.Pressed("autofire") || InputState.ControllerAutofirePressed)
         {
             GameProfile.Profile.AutoFire = !GameProfile.Profile.AutoFire;
@@ -277,10 +275,6 @@ public class RotBoiGame : Game
         }
         if (Keybinds.Pressed("hud_toggle") && State == GameState.GameRun)
             _session!.ToggleWeaponStats();
-        if (Keybinds.Pressed("dev_invincible") && _session is not null)
-            _session.State.BossDebugInvincible = !_session.State.BossDebugInvincible;
-        if (Keybinds.Pressed("dev_level_up") && State == GameState.GameRun)
-            _session!.DebugForceLevelUp();
     }
 
     /// <summary>Ported from main.py's update_camera_controls().</summary>

--- a/RotBoiRemastered/Systems/Keybinds.cs
+++ b/RotBoiRemastered/Systems/Keybinds.cs
@@ -32,9 +32,6 @@ public static class Keybinds
         ("interact", "Interact", Keys.F),
         ("hud_toggle", "Toggle HUD Detail", Keys.Tab),
         ("restart", "Restart Run (while paused)", Keys.R),
-        ("dev_level_up", "DEV: Force Level Up", Keys.F1),
-        ("dev_boss", "DEV: Force Boss Encounter", Keys.B),
-        ("dev_invincible", "DEV: Toggle Boss Invincibility", Keys.Y),
         ("console_toggle", "DEV: Toggle Console", Keys.OemTilde),
     };
 

--- a/RotBoiRemastered/UI/DevConsole.cs
+++ b/RotBoiRemastered/UI/DevConsole.cs
@@ -25,6 +25,8 @@ public readonly record struct ConsoleResult(ConsoleActionKind Kind = ConsoleActi
 ///   /spawn &lt;count&gt; "&lt;item name&gt;" [rarity]  -- drops a loot crate at the player
 ///   /give &lt;count&gt; "&lt;item name&gt;" [rarity]   -- fills empty inventory slots directly
 ///   /god                                    -- toggles RunState.BossDebugInvincible
+///   /boss                                   -- forces the level's boss encounter to start
+///   /levelup                                -- forces an immediate level up
 ///   /extract                                -- runs the same sequence as the pause menu's
 ///                                               Extract button, bypassing its BeaudisDefeated gate
 ///   /help                                   -- lists the above
@@ -104,6 +106,8 @@ public sealed class DevConsole
             Log("/spawn <count> \"<item name>\" [rarity]  -- drop a crate at your position");
             Log("/give <count> \"<item name>\" [rarity]   -- add straight to inventory");
             Log("/god                                    -- toggle invincibility");
+            Log("/boss                                   -- force the boss encounter to start");
+            Log("/levelup                                -- force an immediate level up");
             Log("/extract                                -- end the run as an extraction");
             return default;
         }
@@ -117,6 +121,8 @@ public sealed class DevConsole
             case "spawn": return HandleSpawn(tokens, session);
             case "give": return HandleGive(tokens, session);
             case "god": return HandleGod(session);
+            case "boss": return HandleBoss(session);
+            case "levelup": return HandleLevelUp(session);
             case "extract": return HandleExtract();
             default:
                 Log($"Unknown command: {command} (try /help)");
@@ -157,6 +163,25 @@ public sealed class DevConsole
     {
         session.State.BossDebugInvincible = !session.State.BossDebugInvincible;
         Log($"God mode: {(session.State.BossDebugInvincible ? "ON" : "OFF")}");
+        return default;
+    }
+
+    private ConsoleResult HandleBoss(GameSession session)
+    {
+        if (session.State.ActiveBoss is not null || session.State.BossDebugRequested)
+        {
+            Log("A boss encounter is already active or pending.");
+            return default;
+        }
+        session.State.BossDebugRequested = true;
+        Log("Boss encounter requested.");
+        return default;
+    }
+
+    private ConsoleResult HandleLevelUp(GameSession session)
+    {
+        session.DebugForceLevelUp();
+        Log("Forced a level up.");
         return default;
     }
 


### PR DESCRIPTION
## Summary
- Removed the rebindable "DEV: Force Level Up" (F1), "DEV: Force Boss Encounter" (B), and "DEV: Toggle Boss Invincibility" (Y) keybinds -- admin commands now only come through the console.
- Added `/boss` (force the boss encounter to start) and `/levelup` (force an immediate level up) to `DevConsole`, alongside the existing `/god`.

## Test plan
- [x] `dotnet build RotBoiRemastered.Tests`
- [x] `dotnet test RotBoiRemastered.Tests` -- 442/442 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)